### PR TITLE
Support multi-line mob_farm_bonus.cfg for bonus drop

### DIFF
--- a/Common/src/main/java/de/markusbordihn/easymobfarm/block/entity/MobFarmBlockEntity.java
+++ b/Common/src/main/java/de/markusbordihn/easymobfarm/block/entity/MobFarmBlockEntity.java
@@ -398,13 +398,14 @@ public class MobFarmBlockEntity extends BaseContainerBlockEntity implements Worl
       return;
     }
 
-    // Add optional bonus loot drop based on the mob farm, tier level and captured mob.
-    ItemStack bonusLootDrop =
+    // Add optional bonus loot drops based on the mob farm, tier level and captured mob.
+    List<ItemStack> bonusLootDrops =
         MobFarmBonusConfig.getBonusDrop(this.getFarmType(), this.getFarmTierLevel(), entityType);
-    if (!bonusLootDrop.isEmpty()) {
-      lootDrops.add(bonusLootDrop.copy());
+    for (ItemStack drop : bonusLootDrops) {
+      if (!drop.isEmpty()) {
+        lootDrops.add(drop.copy());
+      }
     }
-
     // Handle loot drops
     this.handleLootDrops(lootDrops);
 

--- a/Common/src/main/java/de/markusbordihn/easymobfarm/client/screen/MobFarmScreen.java
+++ b/Common/src/main/java/de/markusbordihn/easymobfarm/client/screen/MobFarmScreen.java
@@ -362,17 +362,41 @@ public class MobFarmScreen<T extends MobFarmMenu> extends ContainerScreen<T> {
         }
 
         // Add Bonus drop information, if available.
-        ItemStack bonusLootDrop =
-            MobFarmBonusConfig.getBonusDropEntry(
+        java.util.List<ItemStack> bonusLootDrops =
+            MobFarmBonusConfig.getBonusDropEntries(
                 this.getMenu().getMobFarmType(),
                 this.getMenu().getMobFarmTierLevel(),
                 this.entity.getType());
-        if (!bonusLootDrop.isEmpty()) {
+                
+        if (!bonusLootDrops.isEmpty()) {
+          java.util.List<String> names = bonusLootDrops.stream()
+              .map(drop -> drop.getDisplayName().getString())
+              .collect(java.util.stream.Collectors.toList());
+
+          int itemsPerLine = 4;
+
+          String firstChunk = String.join(", ", names.subList(0, Math.min(itemsPerLine, names.size())));
+          if (names.size() > itemsPerLine) {
+             firstChunk += ",";
+          }
+          
           infoText.add(
               TextComponent.getTranslatedTextRaw(
                       Constants.TOOLTIP_FARM_PREFIX + "bonus_drop",
-                      new Object[] {bonusLootDrop.getDisplayName()})
+                      new Object[] {firstChunk})
                   .withStyle(ChatFormatting.GREEN));
+
+          for (int i = itemsPerLine; i < names.size(); i += itemsPerLine) {
+            String nextChunk = String.join(", ", names.subList(i, Math.min(i + itemsPerLine, names.size())));
+            if (i + itemsPerLine < names.size()) {
+               nextChunk += ",";
+            }
+            
+            infoText.add(
+                net.minecraft.network.chat.Component.literal("      " + nextChunk)
+                    .withStyle(ChatFormatting.GREEN));
+          }
+          
         } else {
           infoText.add(
               TextComponent.getTranslatedTextRaw(Constants.TOOLTIP_FARM_PREFIX + "no_bonus_drop")
@@ -456,19 +480,19 @@ public class MobFarmScreen<T extends MobFarmMenu> extends ContainerScreen<T> {
       }
     }
 
-    // Show bonus drop with chance
+    // Show bonus drops with chance
     MobFarmType mobFarmType = this.getMenu().getMobFarmType();
     int tierLevel = this.getMenu().getMobFarmTierLevel();
-    ItemStack bonusDrop =
-        MobFarmBonusConfig.getBonusDropEntry(mobFarmType, tierLevel, this.entity.getType());
-    if (!bonusDrop.isEmpty()) {
-      int chance =
-          MobFarmBonusConfig.getBonusDropChance(mobFarmType, tierLevel, this.entity.getType());
-      if (chance > 0) {
+    
+    java.util.List<MobFarmBonusConfig.BonusDrop> bonusDrops = 
+        MobFarmBonusConfig.getConfiguredBonusDrops(mobFarmType, tierLevel, this.entity.getType());
+    
+    for (MobFarmBonusConfig.BonusDrop drop : bonusDrops) {
+      if (!drop.itemStack.isEmpty() && drop.chance > 0) {
         lootInfo.add(
             TextComponent.getTranslatedTextRaw(
                     Constants.TOOLTIP_FARM_PREFIX + "loot_bonus_chance",
-                    new Object[] {bonusDrop.getDisplayName(), chance})
+                    new Object[] {drop.itemStack.getDisplayName(), drop.chance})
                 .withStyle(ChatFormatting.GREEN));
       }
     }

--- a/Common/src/main/java/de/markusbordihn/easymobfarm/client/screen/MobFarmScreen.java
+++ b/Common/src/main/java/de/markusbordihn/easymobfarm/client/screen/MobFarmScreen.java
@@ -362,41 +362,42 @@ public class MobFarmScreen<T extends MobFarmMenu> extends ContainerScreen<T> {
         }
 
         // Add Bonus drop information, if available.
-        java.util.List<ItemStack> bonusLootDrops =
+        List<ItemStack> bonusLootDrops =
             MobFarmBonusConfig.getBonusDropEntries(
                 this.getMenu().getMobFarmType(),
                 this.getMenu().getMobFarmTierLevel(),
                 this.entity.getType());
-                
+
         if (!bonusLootDrops.isEmpty()) {
-          java.util.List<String> names = bonusLootDrops.stream()
-              .map(drop -> drop.getDisplayName().getString())
-              .collect(java.util.stream.Collectors.toList());
-
+          List<String> bonusLootDropNames =
+              bonusLootDrops.stream().map(drop -> drop.getDisplayName().getString()).toList();
           int itemsPerLine = 4;
-
-          String firstChunk = String.join(", ", names.subList(0, Math.min(itemsPerLine, names.size())));
-          if (names.size() > itemsPerLine) {
-             firstChunk += ",";
+          String firstChunk =
+              String.join(
+                  ", ",
+                  bonusLootDropNames.subList(0, Math.min(itemsPerLine, bonusLootDropNames.size())));
+          if (bonusLootDropNames.size() > itemsPerLine) {
+            firstChunk += ",";
           }
-          
+
           infoText.add(
               TextComponent.getTranslatedTextRaw(
-                      Constants.TOOLTIP_FARM_PREFIX + "bonus_drop",
-                      new Object[] {firstChunk})
+                      Constants.TOOLTIP_FARM_PREFIX + "bonus_drop", new Object[] {firstChunk})
                   .withStyle(ChatFormatting.GREEN));
 
-          for (int i = itemsPerLine; i < names.size(); i += itemsPerLine) {
-            String nextChunk = String.join(", ", names.subList(i, Math.min(i + itemsPerLine, names.size())));
-            if (i + itemsPerLine < names.size()) {
-               nextChunk += ",";
+          for (int i = itemsPerLine; i < bonusLootDropNames.size(); i += itemsPerLine) {
+            String nextChunk =
+                String.join(
+                    ", ",
+                    bonusLootDropNames.subList(
+                        i, Math.min(i + itemsPerLine, bonusLootDropNames.size())));
+            if (i + itemsPerLine < bonusLootDropNames.size()) {
+              nextChunk += ",";
             }
-            
-            infoText.add(
-                net.minecraft.network.chat.Component.literal("      " + nextChunk)
-                    .withStyle(ChatFormatting.GREEN));
+
+            infoText.add(Component.literal("      " + nextChunk).withStyle(ChatFormatting.GREEN));
           }
-          
+
         } else {
           infoText.add(
               TextComponent.getTranslatedTextRaw(Constants.TOOLTIP_FARM_PREFIX + "no_bonus_drop")
@@ -483,16 +484,16 @@ public class MobFarmScreen<T extends MobFarmMenu> extends ContainerScreen<T> {
     // Show bonus drops with chance
     MobFarmType mobFarmType = this.getMenu().getMobFarmType();
     int tierLevel = this.getMenu().getMobFarmTierLevel();
-    
-    java.util.List<MobFarmBonusConfig.BonusDrop> bonusDrops = 
+
+    List<MobFarmBonusConfig.BonusDrop> bonusDrops =
         MobFarmBonusConfig.getConfiguredBonusDrops(mobFarmType, tierLevel, this.entity.getType());
-    
+
     for (MobFarmBonusConfig.BonusDrop drop : bonusDrops) {
-      if (!drop.itemStack.isEmpty() && drop.chance > 0) {
+      if (!drop.itemStack().isEmpty() && drop.chance() > 0) {
         lootInfo.add(
             TextComponent.getTranslatedTextRaw(
                     Constants.TOOLTIP_FARM_PREFIX + "loot_bonus_chance",
-                    new Object[] {drop.itemStack.getDisplayName(), drop.chance})
+                    new Object[] {drop.itemStack().getDisplayName(), drop.chance()})
                 .withStyle(ChatFormatting.GREEN));
       }
     }

--- a/Common/src/main/java/de/markusbordihn/easymobfarm/config/MobFarmBonusConfig.java
+++ b/Common/src/main/java/de/markusbordihn/easymobfarm/config/MobFarmBonusConfig.java
@@ -21,12 +21,17 @@ package de.markusbordihn.easymobfarm.config;
 
 import de.markusbordihn.easymobfarm.data.mobfarm.MobFarmType;
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.Random;
+import java.util.Set;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.entity.EntityType;
@@ -39,327 +44,206 @@ public class MobFarmBonusConfig extends Config {
   public static final String CONFIG_FILE_NAME = "mob_farm_bonus.cfg";
   public static final String CONFIG_FILE_HEADER =
 """
- Mob Farm Bonus Configuration
-
- This configuration file allows you to define the bonus drops for the Mob Farms.
-
- Configuration Format:
- --------------------
- <mob_farm_name>::<tier_level>::<entity_type> = <item_name>::<amount>::<chance 1 of x>
-
- Available Mob Farm Types:
- ------------------------
- - animal_plains_farm: For animals like cows, sheep, chickens, pigs
- - bee_hive_farm: For bees and honey production
- - desert_farm: For desert mobs like husks, rabbits, camels
- - iron_golem_farm: For iron golems and poppy drops
- - jungle_farm: For jungle mobs like parrots, pandas, ocelots
- - monster_plains_cave_farm: For common monsters like zombies, skeletons, spiders
- - nether_fortress_farm: For nether mobs like blazes, magma cubes, wither skeletons
- - ocean_farm: For ocean mobs like cod, salmon, squid, guardians
- - swamp_farm: For swamp mobs like frogs, slimes, witches
-
- Tier Levels (better farms = better bonus chances):
- -------------------------------------------------
- - 0: Basic tier (lowest bonus chance)
- - 1: Improved tier (better bonus chance)
- - 2: Advanced tier (good bonus chance)
- - 3: Elite tier (highest bonus chance)
-
- Configuration Examples:
- ----------------------
- Basic bee farm with 1 in 20 chance for honeycomb:
-   bee_hive_farm::0::minecraft:bee = minecraft:honeycomb::1::20
-
- Elite bee farm with 1 in 5 chance for honeycomb:
-   bee_hive_farm::3::minecraft:bee = minecraft:honeycomb::1::5
-
- Iron golem farm with bonus iron ingots:
-   iron_golem_farm::2::minecraft:iron_golem = minecraft:iron_ingot::2::8
-
- Multiple bonus items for the same mob (different lines):
-   ocean_farm::1::minecraft:cod = minecraft:cod::1::10
-   ocean_farm::1::minecraft:cod = minecraft:bone_meal::1::25
-
- Important Notes:
- ---------------
- - Lower chance numbers = higher drop probability (1 = always, 100 = 1% chance)
- - To disable a bonus drop, set the amount to 0
- - Each mob farm type targets specific biome-appropriate mobs
- - Higher tier farms have better default bonus chances
+# Mob Farm Bonus Configuration
+#
+# This configuration file allows you to define the bonus drops for the Mob Farms.
+#
+# Configuration Format:
+# --------------------
+# <mob_farm_name>::<tier_level>::<entity_type> = <item_name>::<amount>::<chance 1 of x>
+#
+# Available Mob Farm Types:
+# ------------------------
+# - animal_plains_farm: For animals like cows, sheep, chickens, pigs
+# - bee_hive_farm: For bees and honey production
+# - desert_farm: For desert mobs like husks, rabbits, camels
+# - iron_golem_farm: For iron golems and poppy drops
+# - jungle_farm: For jungle mobs like parrots, pandas, ocelots
+# - monster_plains_cave_farm: For common monsters like zombies, skeletons, spiders
+# - nether_fortress_farm: For nether mobs like blazes, magma cubes, wither skeletons
+# - ocean_farm: For ocean mobs like cod, salmon, squid, guardians
+# - swamp_farm: For swamp mobs like frogs, slimes, witches
+#
+# Tier Levels (better farms = better bonus chances):
+# -------------------------------------------------
+# - 0: Basic tier (lowest bonus chance)
+# - 1: Improved tier (better bonus chance)
+# - 2: Advanced tier (good bonus chance)
+# - 3: Elite tier (highest bonus chance)
+#
+# Configuration Examples:
+# ----------------------
+# Basic bee farm with 1 in 20 chance for honeycomb:
+#   bee_hive_farm::0::minecraft:bee = minecraft:honeycomb::1::20
+#
+# Elite bee farm with 1 in 5 chance for honeycomb:
+#   bee_hive_farm::3::minecraft:bee = minecraft:honeycomb::1::5
+#
+# Iron golem farm with bonus iron ingots:
+#   iron_golem_farm::2::minecraft:iron_golem = minecraft:iron_ingot::2::8
+#
+# Multiple bonus items for the same mob (different lines):
+#   ocean_farm::1::minecraft:cod = minecraft:cod::1::10
+#   ocean_farm::1::minecraft:cod = minecraft:bone_meal::1::25
+#
+# Important Notes:
+# ---------------
+# - Lower chance numbers = higher drop probability (1 = always, 100 = 1% chance)
+# - To disable a bonus drop, set the amount to 0
+# - Each mob farm type targets specific biome-appropriate mobs
+# - Higher tier farms have better default bonus chances
 
 """;
   public static final String LOG_PREFIX = "[MobFarmBonusConfig]";
 
   private static final Random random = new Random();
-  private static final HashMap<String, HashMap<Integer, ItemStack>> mobFarmBonusMap =
-      new HashMap<>();
-  private static final HashMap<String, HashMap<Integer, ItemStack>> defaultMobFarmBonusMap =
-      new HashMap<>();
+
+  public static class BonusDrop {
+    public final int chance;
+    public final ItemStack itemStack;
+
+    public BonusDrop(int chance, ItemStack itemStack) {
+      this.chance = chance;
+      this.itemStack = itemStack;
+    }
+  }
+
+  private static final HashMap<String, Integer> displayIndexMap = new HashMap<>();
+
+  private static final HashMap<String, List<BonusDrop>> mobFarmBonusMap = new HashMap<>();
+  private static final HashMap<String, List<BonusDrop>> defaultMobFarmBonusMap = new HashMap<>();
 
   static {
     // Animal Plains Farm Bonus
-    defaultMobFarmBonusMap.put(
-        MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::0::minecraft:cow",
-        new HashMap<>(Map.of(20, new ItemStack(Items.LEATHER, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::1::minecraft:cow",
-        new HashMap<>(Map.of(15, new ItemStack(Items.LEATHER, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::2::minecraft:cow",
-        new HashMap<>(Map.of(10, new ItemStack(Items.LEATHER, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::3::minecraft:cow",
-        new HashMap<>(Map.of(5, new ItemStack(Items.LEATHER, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::0::minecraft:sheep",
-        new HashMap<>(Map.of(20, new ItemStack(Items.WHITE_WOOL, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::1::minecraft:sheep",
-        new HashMap<>(Map.of(15, new ItemStack(Items.WHITE_WOOL, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::2::minecraft:sheep",
-        new HashMap<>(Map.of(10, new ItemStack(Items.WHITE_WOOL, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::3::minecraft:sheep",
-        new HashMap<>(Map.of(5, new ItemStack(Items.WHITE_WOOL, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::0::minecraft:chicken",
-        new HashMap<>(Map.of(20, new ItemStack(Items.EGG, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::1::minecraft:chicken",
-        new HashMap<>(Map.of(15, new ItemStack(Items.EGG, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::2::minecraft:chicken",
-        new HashMap<>(Map.of(10, new ItemStack(Items.EGG, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::3::minecraft:chicken",
-        new HashMap<>(Map.of(5, new ItemStack(Items.EGG, 1))));
+    defaultMobFarmBonusMap.put(MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::0::minecraft:cow", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.LEATHER, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::1::minecraft:cow", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.LEATHER, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::2::minecraft:cow", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.LEATHER, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::3::minecraft:cow", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.LEATHER, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::0::minecraft:sheep", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.WHITE_WOOL, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::1::minecraft:sheep", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.WHITE_WOOL, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::2::minecraft:sheep", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.WHITE_WOOL, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::3::minecraft:sheep", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.WHITE_WOOL, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::0::minecraft:chicken", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.EGG, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::1::minecraft:chicken", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.EGG, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::2::minecraft:chicken", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.EGG, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::3::minecraft:chicken", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.EGG, 1)))));
 
     // Bee Hive Farm Bonus
-    defaultMobFarmBonusMap.put(
-        MobFarmType.BEE_HIVE_FARM.getId() + "::0::minecraft:bee",
-        new HashMap<>(Map.of(20, new ItemStack(Items.HONEYCOMB, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.BEE_HIVE_FARM.getId() + "::1::minecraft:bee",
-        new HashMap<>(Map.of(15, new ItemStack(Items.HONEYCOMB, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.BEE_HIVE_FARM.getId() + "::2::minecraft:bee",
-        new HashMap<>(Map.of(10, new ItemStack(Items.HONEYCOMB, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.BEE_HIVE_FARM.getId() + "::3::minecraft:bee",
-        new HashMap<>(Map.of(5, new ItemStack(Items.HONEYCOMB, 1))));
+    defaultMobFarmBonusMap.put(MobFarmType.BEE_HIVE_FARM.getId() + "::0::minecraft:bee", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.HONEYCOMB, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.BEE_HIVE_FARM.getId() + "::1::minecraft:bee", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.HONEYCOMB, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.BEE_HIVE_FARM.getId() + "::2::minecraft:bee", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.HONEYCOMB, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.BEE_HIVE_FARM.getId() + "::3::minecraft:bee", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.HONEYCOMB, 1)))));
 
     // Desert Farm Bonus
-    defaultMobFarmBonusMap.put(
-        MobFarmType.DESERT_FARM.getId() + "::0::minecraft:husk",
-        new HashMap<>(Map.of(20, new ItemStack(Items.SAND, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.DESERT_FARM.getId() + "::1::minecraft:husk",
-        new HashMap<>(Map.of(15, new ItemStack(Items.SAND, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.DESERT_FARM.getId() + "::2::minecraft:husk",
-        new HashMap<>(Map.of(10, new ItemStack(Items.SAND, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.DESERT_FARM.getId() + "::3::minecraft:husk",
-        new HashMap<>(Map.of(5, new ItemStack(Items.SAND, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.DESERT_FARM.getId() + "::0::minecraft:rabbit",
-        new HashMap<>(Map.of(20, new ItemStack(Items.RABBIT_HIDE, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.DESERT_FARM.getId() + "::1::minecraft:rabbit",
-        new HashMap<>(Map.of(15, new ItemStack(Items.RABBIT_HIDE, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.DESERT_FARM.getId() + "::2::minecraft:rabbit",
-        new HashMap<>(Map.of(10, new ItemStack(Items.RABBIT_HIDE, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.DESERT_FARM.getId() + "::3::minecraft:rabbit",
-        new HashMap<>(Map.of(5, new ItemStack(Items.RABBIT_HIDE, 1))));
+    defaultMobFarmBonusMap.put(MobFarmType.DESERT_FARM.getId() + "::0::minecraft:husk", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.SAND, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.DESERT_FARM.getId() + "::1::minecraft:husk", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.SAND, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.DESERT_FARM.getId() + "::2::minecraft:husk", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.SAND, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.DESERT_FARM.getId() + "::3::minecraft:husk", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.SAND, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.DESERT_FARM.getId() + "::0::minecraft:rabbit", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.RABBIT_HIDE, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.DESERT_FARM.getId() + "::1::minecraft:rabbit", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.RABBIT_HIDE, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.DESERT_FARM.getId() + "::2::minecraft:rabbit", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.RABBIT_HIDE, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.DESERT_FARM.getId() + "::3::minecraft:rabbit", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.RABBIT_HIDE, 1)))));
 
     // Iron Golem Farm Bonus
-    defaultMobFarmBonusMap.put(
-        MobFarmType.IRON_GOLEM_FARM.getId() + "::0::minecraft:iron_golem",
-        new HashMap<>(Map.of(20, new ItemStack(Items.IRON_INGOT, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.IRON_GOLEM_FARM.getId() + "::1::minecraft:iron_golem",
-        new HashMap<>(Map.of(15, new ItemStack(Items.IRON_INGOT, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.IRON_GOLEM_FARM.getId() + "::2::minecraft:iron_golem",
-        new HashMap<>(Map.of(10, new ItemStack(Items.IRON_INGOT, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.IRON_GOLEM_FARM.getId() + "::3::minecraft:iron_golem",
-        new HashMap<>(Map.of(5, new ItemStack(Items.IRON_INGOT, 1))));
+    defaultMobFarmBonusMap.put(MobFarmType.IRON_GOLEM_FARM.getId() + "::0::minecraft:iron_golem", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.IRON_INGOT, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.IRON_GOLEM_FARM.getId() + "::1::minecraft:iron_golem", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.IRON_INGOT, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.IRON_GOLEM_FARM.getId() + "::2::minecraft:iron_golem", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.IRON_INGOT, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.IRON_GOLEM_FARM.getId() + "::3::minecraft:iron_golem", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.IRON_INGOT, 1)))));
 
     // Jungle Farm Bonus
-    defaultMobFarmBonusMap.put(
-        MobFarmType.JUNGLE_FARM.getId() + "::0::minecraft:parrot",
-        new HashMap<>(Map.of(20, new ItemStack(Items.FEATHER, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.JUNGLE_FARM.getId() + "::1::minecraft:parrot",
-        new HashMap<>(Map.of(15, new ItemStack(Items.FEATHER, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.JUNGLE_FARM.getId() + "::2::minecraft:parrot",
-        new HashMap<>(Map.of(10, new ItemStack(Items.FEATHER, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.JUNGLE_FARM.getId() + "::3::minecraft:parrot",
-        new HashMap<>(Map.of(5, new ItemStack(Items.FEATHER, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.JUNGLE_FARM.getId() + "::0::minecraft:panda",
-        new HashMap<>(Map.of(20, new ItemStack(Items.BAMBOO, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.JUNGLE_FARM.getId() + "::1::minecraft:panda",
-        new HashMap<>(Map.of(15, new ItemStack(Items.BAMBOO, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.JUNGLE_FARM.getId() + "::2::minecraft:panda",
-        new HashMap<>(Map.of(10, new ItemStack(Items.BAMBOO, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.JUNGLE_FARM.getId() + "::3::minecraft:panda",
-        new HashMap<>(Map.of(5, new ItemStack(Items.BAMBOO, 1))));
+    defaultMobFarmBonusMap.put(MobFarmType.JUNGLE_FARM.getId() + "::0::minecraft:parrot", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.FEATHER, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.JUNGLE_FARM.getId() + "::1::minecraft:parrot", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.FEATHER, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.JUNGLE_FARM.getId() + "::2::minecraft:parrot", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.FEATHER, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.JUNGLE_FARM.getId() + "::3::minecraft:parrot", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.FEATHER, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.JUNGLE_FARM.getId() + "::0::minecraft:panda", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.BAMBOO, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.JUNGLE_FARM.getId() + "::1::minecraft:panda", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.BAMBOO, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.JUNGLE_FARM.getId() + "::2::minecraft:panda", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.BAMBOO, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.JUNGLE_FARM.getId() + "::3::minecraft:panda", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.BAMBOO, 1)))));
 
     // Monster Plains Cave Farm Bonus
-    defaultMobFarmBonusMap.put(
-        MobFarmType.MONSTER_PLAINS_CAVE_FARM.getId() + "::0::minecraft:zombie",
-        new HashMap<>(Map.of(20, new ItemStack(Items.ROTTEN_FLESH, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.MONSTER_PLAINS_CAVE_FARM.getId() + "::1::minecraft:zombie",
-        new HashMap<>(Map.of(15, new ItemStack(Items.ROTTEN_FLESH, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.MONSTER_PLAINS_CAVE_FARM.getId() + "::2::minecraft:zombie",
-        new HashMap<>(Map.of(10, new ItemStack(Items.ROTTEN_FLESH, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.MONSTER_PLAINS_CAVE_FARM.getId() + "::3::minecraft:zombie",
-        new HashMap<>(Map.of(5, new ItemStack(Items.ROTTEN_FLESH, 1))));
+    defaultMobFarmBonusMap.put(MobFarmType.MONSTER_PLAINS_CAVE_FARM.getId() + "::0::minecraft:zombie", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.ROTTEN_FLESH, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.MONSTER_PLAINS_CAVE_FARM.getId() + "::1::minecraft:zombie", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.ROTTEN_FLESH, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.MONSTER_PLAINS_CAVE_FARM.getId() + "::2::minecraft:zombie", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.ROTTEN_FLESH, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.MONSTER_PLAINS_CAVE_FARM.getId() + "::3::minecraft:zombie", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.ROTTEN_FLESH, 1)))));
 
     // Nether Fortress Farm Bonus
-    defaultMobFarmBonusMap.put(
-        MobFarmType.NETHER_FORTRESS_FARM.getId() + "::0::minecraft:blaze",
-        new HashMap<>(Map.of(20, new ItemStack(Items.BLAZE_ROD, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.NETHER_FORTRESS_FARM.getId() + "::1::minecraft:blaze",
-        new HashMap<>(Map.of(15, new ItemStack(Items.BLAZE_ROD, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.NETHER_FORTRESS_FARM.getId() + "::2::minecraft:blaze",
-        new HashMap<>(Map.of(10, new ItemStack(Items.BLAZE_ROD, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.NETHER_FORTRESS_FARM.getId() + "::3::minecraft:blaze",
-        new HashMap<>(Map.of(5, new ItemStack(Items.BLAZE_ROD, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.NETHER_FORTRESS_FARM.getId() + "::0::minecraft:magma_cube",
-        new HashMap<>(Map.of(20, new ItemStack(Items.MAGMA_CREAM, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.NETHER_FORTRESS_FARM.getId() + "::1::minecraft:magma_cube",
-        new HashMap<>(Map.of(15, new ItemStack(Items.MAGMA_CREAM, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.NETHER_FORTRESS_FARM.getId() + "::2::minecraft:magma_cube",
-        new HashMap<>(Map.of(10, new ItemStack(Items.MAGMA_CREAM, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.NETHER_FORTRESS_FARM.getId() + "::3::minecraft:magma_cube",
-        new HashMap<>(Map.of(5, new ItemStack(Items.MAGMA_CREAM, 1))));
+    defaultMobFarmBonusMap.put(MobFarmType.NETHER_FORTRESS_FARM.getId() + "::0::minecraft:blaze", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.BLAZE_ROD, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.NETHER_FORTRESS_FARM.getId() + "::1::minecraft:blaze", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.BLAZE_ROD, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.NETHER_FORTRESS_FARM.getId() + "::2::minecraft:blaze", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.BLAZE_ROD, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.NETHER_FORTRESS_FARM.getId() + "::3::minecraft:blaze", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.BLAZE_ROD, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.NETHER_FORTRESS_FARM.getId() + "::0::minecraft:magma_cube", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.MAGMA_CREAM, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.NETHER_FORTRESS_FARM.getId() + "::1::minecraft:magma_cube", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.MAGMA_CREAM, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.NETHER_FORTRESS_FARM.getId() + "::2::minecraft:magma_cube", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.MAGMA_CREAM, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.NETHER_FORTRESS_FARM.getId() + "::3::minecraft:magma_cube", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.MAGMA_CREAM, 1)))));
 
     // Ocean Farm Bonus
-    defaultMobFarmBonusMap.put(
-        MobFarmType.OCEAN_FARM.getId() + "::0::minecraft:cod",
-        new HashMap<>(Map.of(20, new ItemStack(Items.COD, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.OCEAN_FARM.getId() + "::1::minecraft:cod",
-        new HashMap<>(Map.of(15, new ItemStack(Items.COD, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.OCEAN_FARM.getId() + "::2::minecraft:cod",
-        new HashMap<>(Map.of(10, new ItemStack(Items.COD, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.OCEAN_FARM.getId() + "::3::minecraft:cod",
-        new HashMap<>(Map.of(5, new ItemStack(Items.COD, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.OCEAN_FARM.getId() + "::0::minecraft:squid",
-        new HashMap<>(Map.of(20, new ItemStack(Items.INK_SAC, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.OCEAN_FARM.getId() + "::1::minecraft:squid",
-        new HashMap<>(Map.of(15, new ItemStack(Items.INK_SAC, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.OCEAN_FARM.getId() + "::2::minecraft:squid",
-        new HashMap<>(Map.of(10, new ItemStack(Items.INK_SAC, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.OCEAN_FARM.getId() + "::3::minecraft:squid",
-        new HashMap<>(Map.of(5, new ItemStack(Items.INK_SAC, 1))));
+    defaultMobFarmBonusMap.put(MobFarmType.OCEAN_FARM.getId() + "::0::minecraft:cod", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.COD, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.OCEAN_FARM.getId() + "::1::minecraft:cod", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.COD, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.OCEAN_FARM.getId() + "::2::minecraft:cod", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.COD, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.OCEAN_FARM.getId() + "::3::minecraft:cod", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.COD, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.OCEAN_FARM.getId() + "::0::minecraft:squid", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.INK_SAC, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.OCEAN_FARM.getId() + "::1::minecraft:squid", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.INK_SAC, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.OCEAN_FARM.getId() + "::2::minecraft:squid", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.INK_SAC, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.OCEAN_FARM.getId() + "::3::minecraft:squid", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.INK_SAC, 1)))));
 
     // Swamp Farm Bonus
-    defaultMobFarmBonusMap.put(
-        MobFarmType.SWAMP_FARM.getId() + "::0::minecraft:frog",
-        new HashMap<>(Map.of(20, new ItemStack(Items.SLIME_BALL, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.SWAMP_FARM.getId() + "::1::minecraft:frog",
-        new HashMap<>(Map.of(15, new ItemStack(Items.SLIME_BALL, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.SWAMP_FARM.getId() + "::2::minecraft:frog",
-        new HashMap<>(Map.of(10, new ItemStack(Items.SLIME_BALL, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.SWAMP_FARM.getId() + "::3::minecraft:frog",
-        new HashMap<>(Map.of(5, new ItemStack(Items.SLIME_BALL, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.SWAMP_FARM.getId() + "::0::minecraft:slime",
-        new HashMap<>(Map.of(20, new ItemStack(Items.SLIME_BALL, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.SWAMP_FARM.getId() + "::1::minecraft:slime",
-        new HashMap<>(Map.of(15, new ItemStack(Items.SLIME_BALL, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.SWAMP_FARM.getId() + "::2::minecraft:slime",
-        new HashMap<>(Map.of(10, new ItemStack(Items.SLIME_BALL, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.SWAMP_FARM.getId() + "::3::minecraft:slime",
-        new HashMap<>(Map.of(5, new ItemStack(Items.SLIME_BALL, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.SWAMP_FARM.getId() + "::0::minecraft:witch",
-        new HashMap<>(Map.of(20, new ItemStack(Items.REDSTONE, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.SWAMP_FARM.getId() + "::1::minecraft:witch",
-        new HashMap<>(Map.of(15, new ItemStack(Items.REDSTONE, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.SWAMP_FARM.getId() + "::2::minecraft:witch",
-        new HashMap<>(Map.of(10, new ItemStack(Items.REDSTONE, 1))));
-    defaultMobFarmBonusMap.put(
-        MobFarmType.SWAMP_FARM.getId() + "::3::minecraft:witch",
-        new HashMap<>(Map.of(5, new ItemStack(Items.REDSTONE, 1))));
+    defaultMobFarmBonusMap.put(MobFarmType.SWAMP_FARM.getId() + "::0::minecraft:frog", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.SLIME_BALL, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.SWAMP_FARM.getId() + "::1::minecraft:frog", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.SLIME_BALL, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.SWAMP_FARM.getId() + "::2::minecraft:frog", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.SLIME_BALL, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.SWAMP_FARM.getId() + "::3::minecraft:frog", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.SLIME_BALL, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.SWAMP_FARM.getId() + "::0::minecraft:slime", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.SLIME_BALL, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.SWAMP_FARM.getId() + "::1::minecraft:slime", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.SLIME_BALL, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.SWAMP_FARM.getId() + "::2::minecraft:slime", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.SLIME_BALL, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.SWAMP_FARM.getId() + "::3::minecraft:slime", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.SLIME_BALL, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.SWAMP_FARM.getId() + "::0::minecraft:witch", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.REDSTONE, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.SWAMP_FARM.getId() + "::1::minecraft:witch", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.REDSTONE, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.SWAMP_FARM.getId() + "::2::minecraft:witch", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.REDSTONE, 1)))));
+    defaultMobFarmBonusMap.put(MobFarmType.SWAMP_FARM.getId() + "::3::minecraft:witch", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.REDSTONE, 1)))));
   }
 
   public static void registerConfig() {
-    registerConfigFile(CONFIG_FILE_NAME, CONFIG_FILE_HEADER);
     parseConfigFile();
   }
 
   public static void parseConfigFile() {
     File configFile = getConfigFile(CONFIG_FILE_NAME);
-    Properties properties = readConfigFile(configFile);
-    Properties unmodifiedProperties = (Properties) properties.clone();
+    mobFarmBonusMap.clear();
 
-    // Add default values to config file, if not present.
-    defaultMobFarmBonusMap.forEach(
-        (mobFarmName, bonusMap) -> {
-          if (!properties.containsKey(mobFarmName)) {
-            bonusMap.forEach(
-                (chance, itemStack) -> {
-                  String itemName = BuiltInRegistries.ITEM.getKey(itemStack.getItem()).toString();
-                  String value = itemName + "::" + itemStack.getCount() + "::" + chance;
-                  properties.setProperty(mobFarmName, value);
-                });
-          }
-        });
+    List<String> fileLines = new ArrayList<>();
+    
+    try {
+      if (!configFile.exists()) {
+        Files.writeString(configFile.toPath(), CONFIG_FILE_HEADER);
+      } else {
+        fileLines = Files.readAllLines(configFile.toPath());
+      }
+    } catch (Exception e) {
+      log.error("{} Failed to read config file {}", LOG_PREFIX, CONFIG_FILE_NAME, e);
+      return;
+    }
 
-    // Parse config file
-    properties.forEach(
-        (key, value) -> {
-          // Parse key to extract mob farm name, tier level and entity type
-          String[] keyParts = parseKey((String) key);
-          if (keyParts == null) {
-            return;
-          }
+    Set<String> loadedKeys = new HashSet<>();
 
-          // Parse value to extract item name, amount and chance
-          String[] valueParts = parseValue((String) value);
-          if (valueParts == null || valueParts[0].isEmpty()) {
-            return;
-          }
+    for (String line : fileLines) {
+      String trimmed = line.trim();
+      if (trimmed.isEmpty() || trimmed.startsWith("#")) {
+        continue;
+      }
 
+      String cleanLine = trimmed.replace("\\:", ":");
+      String[] parts = cleanLine.split("=", 2);
+      
+      if (parts.length == 2) {
+        String key = parts[0].trim();
+        String value = parts[1].trim();
+
+        String[] keyParts = parseKey(key);
+        String[] valueParts = parseValue(value);
+
+        if (keyParts != null && valueParts != null && !valueParts[0].isEmpty()) {
           try {
+            String cleanKey = keyParts[0] + "::" + keyParts[1] + "::" + keyParts[2];
+            loadedKeys.add(cleanKey);
             addBonusDropEntry(
                 keyParts[0],
                 Integer.parseInt(keyParts[1]),
@@ -368,17 +252,44 @@ public class MobFarmBonusConfig extends Config {
                 valueParts[0],
                 Integer.parseInt(valueParts[1]));
           } catch (NumberFormatException e) {
-            log.error(
-                "{} Invalid number format in config file {}: key={}, value={}",
-                LOG_PREFIX,
-                CONFIG_FILE_NAME,
-                key,
-                value);
+            log.error("{} Invalid number format in config file {}: {}", LOG_PREFIX, CONFIG_FILE_NAME, line);
           }
-        });
+        }
+      }
+    }
 
-    // Update config file if needed
-    updateConfigFileIfChanged(configFile, CONFIG_FILE_HEADER, properties, unmodifiedProperties);
+    boolean needsUpdate = false;
+    List<String> appendLines = new ArrayList<>();
+
+    for (Map.Entry<String, List<BonusDrop>> entry : defaultMobFarmBonusMap.entrySet()) {
+      String defaultKey = entry.getKey();
+      if (!loadedKeys.contains(defaultKey)) {
+        needsUpdate = true;
+        for (BonusDrop drop : entry.getValue()) {
+          String itemName = BuiltInRegistries.ITEM.getKey(drop.itemStack.getItem()).toString();
+          String writeKey = defaultKey.replace(":", "\\:");
+          String writeValue = (itemName + "::" + drop.itemStack.getCount() + "::" + drop.chance).replace(":", "\\:");
+          
+          appendLines.add(writeKey + "=" + writeValue);
+
+          addBonusDropEntry(
+              defaultKey.split("::")[0],
+              Integer.parseInt(defaultKey.split("::")[1]),
+              defaultKey.split("::")[2],
+              drop.chance,
+              itemName,
+              drop.itemStack.getCount());
+        }
+      }
+    }
+
+    if (needsUpdate) {
+      try {
+        Files.write(configFile.toPath(), appendLines, StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+      } catch (Exception e) {
+        log.error("{} Failed to update config file {}", LOG_PREFIX, CONFIG_FILE_NAME, e);
+      }
+    }
   }
 
   public static String getMobFarmKey(String mobFarmName, int tierLevel, String entityType) {
@@ -393,11 +304,9 @@ public class MobFarmBonusConfig extends Config {
       String itemName,
       int amount) {
 
-    // Check if item name is valid
     Optional<Item> item = BuiltInRegistries.ITEM.getOptional(Identifier.tryParse(itemName));
     if (item.isEmpty() || item.get() == Items.AIR) {
-      log.error(
-          "{} Invalid item name {} in config file {}", LOG_PREFIX, itemName, CONFIG_FILE_NAME);
+      log.error("{} Invalid item name {} in config file {}", LOG_PREFIX, itemName, CONFIG_FILE_NAME);
       return;
     }
 
@@ -406,11 +315,7 @@ public class MobFarmBonusConfig extends Config {
       addBonusDropEntry(
           mobFarmType, tierLevel, entityType, chance, new ItemStack(item.get(), amount));
     } catch (IllegalArgumentException e) {
-      log.error(
-          "{} Invalid mob farm name {} in config file {}",
-          LOG_PREFIX,
-          mobFarmName,
-          CONFIG_FILE_NAME);
+      log.error("{} Invalid mob farm name {} in config file {}", LOG_PREFIX, mobFarmName, CONFIG_FILE_NAME);
     }
   }
 
@@ -421,142 +326,99 @@ public class MobFarmBonusConfig extends Config {
       int chance,
       final ItemStack itemStack) {
 
-    // Check if item stack amount is valid
     if (itemStack.isEmpty()) {
-      log.error(
-          "{} Invalid item stack {} in config file {}", LOG_PREFIX, itemStack, CONFIG_FILE_NAME);
+      log.error("{} Invalid item stack {} in config file {}", LOG_PREFIX, itemStack, CONFIG_FILE_NAME);
       return;
     }
 
-    // Check if entity type is valid
     if (BuiltInRegistries.ENTITY_TYPE.getOptional(Identifier.tryParse(entityType)).isEmpty()) {
-      log.error(
-          "{} Invalid entity type {} in config file {}", LOG_PREFIX, entityType, CONFIG_FILE_NAME);
+      log.error("{} Invalid entity type {} in config file {}", LOG_PREFIX, entityType, CONFIG_FILE_NAME);
       return;
     }
 
-    // Validate tier level (0-3)
     if (tierLevel < 0 || tierLevel > 3) {
-      log.warn(
-          "{} Tier level {} is outside valid range (0-3) for {} in config file {}",
-          LOG_PREFIX,
-          tierLevel,
-          entityType,
-          CONFIG_FILE_NAME);
+      log.warn("{} Tier level {} is outside valid range (0-3) for {} in config file {}", LOG_PREFIX, tierLevel, entityType, CONFIG_FILE_NAME);
       tierLevel = 0;
     }
 
-    // Validate chance value (must be >= 1)
     if (chance < 1) {
-      log.warn(
-          "{} Invalid chance value {} (must be >= 1) for {} in config file {}, using default of 5",
-          LOG_PREFIX,
-          chance,
-          entityType,
-          CONFIG_FILE_NAME);
+      log.warn("{} Invalid chance value {} (must be >= 1) for {} in config file {}, using default of 5", LOG_PREFIX, chance, entityType, CONFIG_FILE_NAME);
       chance = 5;
     }
 
-    // Validate drop amount against item max stack size
     int maxStackSize = itemStack.getMaxStackSize();
     int configuredAmount = itemStack.getCount();
     int maxAllowedAmount = maxStackSize * MobFarmConfig.maxBonusDropMultiplier;
 
     if (configuredAmount > maxAllowedAmount) {
-      log.warn(
-          "{} Configured amount {} exceeds maximum allowed {} ({}x stack size of {}) for {} in config file {}, capping to maximum",
-          LOG_PREFIX,
-          configuredAmount,
-          maxAllowedAmount,
-          MobFarmConfig.maxBonusDropMultiplier,
-          maxStackSize,
-          entityType,
-          CONFIG_FILE_NAME);
+      log.warn("{} Configured amount {} exceeds maximum allowed {} ({}x stack size of {}) for {} in config file {}, capping to maximum",
+          LOG_PREFIX, configuredAmount, maxAllowedAmount, MobFarmConfig.maxBonusDropMultiplier, maxStackSize, entityType, CONFIG_FILE_NAME);
       itemStack.setCount(maxAllowedAmount);
     } else if (configuredAmount > maxStackSize * 10) {
-      log.warn(
-          "{} High drop amount {} configured ({}x stack size of {}) for {} - ensure your modpack supports this with storage mods",
-          LOG_PREFIX,
-          configuredAmount,
-          configuredAmount / maxStackSize,
-          maxStackSize,
-          entityType);
+      log.warn("{} High drop amount {} configured ({}x stack size of {}) for {} - ensure your modpack supports this with storage mods",
+          LOG_PREFIX, configuredAmount, configuredAmount / maxStackSize, maxStackSize, entityType);
     }
 
-    // Add bonus drop entry to the map
     String mobFarmKey = getMobFarmKey(mobFarmType.getId(), tierLevel, entityType);
-    log.info(
-        "{} Add {} with a chance of 1 of {} for {}.", LOG_PREFIX, mobFarmKey, chance, itemStack);
-    mobFarmBonusMap.computeIfAbsent(mobFarmKey, k -> new HashMap<>()).put(chance, itemStack);
+    log.info("{} Add {} with a chance of 1 of {} for {}.", LOG_PREFIX, mobFarmKey, chance, itemStack);
+    
+    mobFarmBonusMap.computeIfAbsent(mobFarmKey, k -> new ArrayList<>()).add(new BonusDrop(chance, itemStack));
   }
 
-  public static ItemStack getBonusDropEntry(
-      MobFarmType mobFarmType, int tierLevel, EntityType<?> entityType) {
-    return getBonusDropEntry(
-        mobFarmType.getId(),
-        tierLevel,
-        String.valueOf(BuiltInRegistries.ENTITY_TYPE.getKey(entityType)));
+  public static ItemStack getBonusDropEntry(MobFarmType mobFarmType, int tierLevel, EntityType<?> entityType) {
+    return getBonusDropEntry(mobFarmType.getId(), tierLevel, String.valueOf(BuiltInRegistries.ENTITY_TYPE.getKey(entityType)));
   }
 
   public static ItemStack getBonusDropEntry(String mobFarmName, int tierLevel, String entityType) {
     if (!hasBonusDrop(mobFarmName, tierLevel, entityType)) {
       return ItemStack.EMPTY;
     }
-    return mobFarmBonusMap
-        .get(getMobFarmKey(mobFarmName, tierLevel, entityType))
-        .entrySet()
-        .stream()
-        .map(Map.Entry::getValue)
-        .findFirst()
-        .orElse(ItemStack.EMPTY);
+    String key = getMobFarmKey(mobFarmName, tierLevel, entityType);
+    List<BonusDrop> drops = mobFarmBonusMap.get(key);
+    int index = displayIndexMap.computeIfAbsent(key, k -> 0) % drops.size();
+    return drops.get(index).itemStack.copy();
   }
 
-  public static int getBonusDropChance(
-      MobFarmType mobFarmType, int tierLevel, EntityType<?> entityType) {
-    return getBonusDropChance(
-        mobFarmType.getId(),
-        tierLevel,
-        String.valueOf(BuiltInRegistries.ENTITY_TYPE.getKey(entityType)));
+  public static int getBonusDropChance(MobFarmType mobFarmType, int tierLevel, EntityType<?> entityType) {
+    return getBonusDropChance(mobFarmType.getId(), tierLevel, String.valueOf(BuiltInRegistries.ENTITY_TYPE.getKey(entityType)));
   }
 
   public static int getBonusDropChance(String mobFarmName, int tierLevel, String entityType) {
     if (!hasBonusDrop(mobFarmName, tierLevel, entityType)) {
       return 0;
     }
-    return mobFarmBonusMap
-        .get(getMobFarmKey(mobFarmName, tierLevel, entityType))
-        .entrySet()
-        .stream()
-        .map(Map.Entry::getKey)
-        .findFirst()
-        .orElse(0);
+    String key = getMobFarmKey(mobFarmName, tierLevel, entityType);
+    List<BonusDrop> drops = mobFarmBonusMap.get(key);
+    int index = displayIndexMap.computeIfAbsent(key, k -> 0) % drops.size();
+    return drops.get(index).chance;
   }
 
-  public static ItemStack getBonusDrop(
-      MobFarmType mobFarmType, int tierLevel, EntityType<?> entityType) {
-    return getBonusDrop(
-        mobFarmType.getId(),
-        tierLevel,
-        String.valueOf(BuiltInRegistries.ENTITY_TYPE.getKey(entityType)));
+  public static ItemStack getBonusDrop(MobFarmType mobFarmType, int tierLevel, EntityType<?> entityType) {
+    return getBonusDrop(mobFarmType.getId(), tierLevel, String.valueOf(BuiltInRegistries.ENTITY_TYPE.getKey(entityType)));
   }
 
   public static ItemStack getBonusDrop(String mobFarmName, int tierLevel, String entityType) {
     if (!hasBonusDrop(mobFarmName, tierLevel, entityType)) {
       return ItemStack.EMPTY;
     }
-    return mobFarmBonusMap
-        .get(getMobFarmKey(mobFarmName, tierLevel, entityType))
-        .entrySet()
-        .stream()
-        .filter(entry -> random.nextInt(entry.getKey()) == 0)
-        .map(Map.Entry::getValue)
-        .findFirst()
-        .orElse(ItemStack.EMPTY);
+    
+    String key = getMobFarmKey(mobFarmName, tierLevel, entityType);
+    List<BonusDrop> drops = mobFarmBonusMap.get(key);
+    
+    int currentIndex = displayIndexMap.computeIfAbsent(key, k -> 0) % drops.size();
+    BonusDrop currentDrop = drops.get(currentIndex);
+    
+    displayIndexMap.put(key, (currentIndex + 1) % drops.size());
+    
+    if (random.nextInt(currentDrop.chance) == 0) {
+      return currentDrop.itemStack.copy();
+    }
+    
+    return ItemStack.EMPTY;
   }
 
   public static boolean hasBonusDrop(String mobFarmName, int tierLevel, EntityType<?> entityType) {
-    return hasBonusDrop(
-        mobFarmName, tierLevel, String.valueOf(BuiltInRegistries.ENTITY_TYPE.getKey(entityType)));
+    return hasBonusDrop(mobFarmName, tierLevel, String.valueOf(BuiltInRegistries.ENTITY_TYPE.getKey(entityType)));
   }
 
   public static boolean hasBonusDrop(String mobFarmName, int tierLevel, String entityType) {

--- a/Common/src/main/java/de/markusbordihn/easymobfarm/config/MobFarmBonusConfig.java
+++ b/Common/src/main/java/de/markusbordihn/easymobfarm/config/MobFarmBonusConfig.java
@@ -21,17 +21,13 @@ package de.markusbordihn.easymobfarm.config;
 
 import de.markusbordihn.easymobfarm.data.mobfarm.MobFarmType;
 import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.Random;
-import java.util.Set;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.entity.EntityType;
@@ -79,12 +75,8 @@ public class MobFarmBonusConfig extends Config {
 # Elite bee farm with 1 in 5 chance for honeycomb:
 #   bee_hive_farm::3::minecraft:bee = minecraft:honeycomb::1::5
 #
-# Iron golem farm with bonus iron ingots:
-#   iron_golem_farm::2::minecraft:iron_golem = minecraft:iron_ingot::2::8
-#
-# Multiple bonus items for the same mob (different lines):
-#   ocean_farm::1::minecraft:cod = minecraft:cod::1::10
-#   ocean_farm::1::minecraft:cod = minecraft:bone_meal::1::25
+# Multiple bonus items for the same mob (using list syntax):
+#   ocean_farm::1::minecraft:cod = [minecraft:cod::1::10, minecraft:bone_meal::1::25]
 #
 # Important Notes:
 # ---------------
@@ -107,8 +99,6 @@ public class MobFarmBonusConfig extends Config {
       this.itemStack = itemStack;
     }
   }
-
-  private static final HashMap<String, Integer> displayIndexMap = new HashMap<>();
 
   private static final HashMap<String, List<BonusDrop>> mobFarmBonusMap = new HashMap<>();
   private static final HashMap<String, List<BonusDrop>> defaultMobFarmBonusMap = new HashMap<>();
@@ -202,93 +192,78 @@ public class MobFarmBonusConfig extends Config {
   }
 
   public static void registerConfig() {
+    registerConfigFile(CONFIG_FILE_NAME, CONFIG_FILE_HEADER);
     parseConfigFile();
   }
 
   public static void parseConfigFile() {
     File configFile = getConfigFile(CONFIG_FILE_NAME);
+    Properties properties = readConfigFile(configFile);
+    Properties unmodifiedProperties = (Properties) properties.clone();
+
     mobFarmBonusMap.clear();
 
-    List<String> fileLines = new ArrayList<>();
-    
-    try {
-      if (!configFile.exists()) {
-        Files.writeString(configFile.toPath(), CONFIG_FILE_HEADER);
-      } else {
-        fileLines = Files.readAllLines(configFile.toPath());
-      }
-    } catch (Exception e) {
-      log.error("{} Failed to read config file {}", LOG_PREFIX, CONFIG_FILE_NAME, e);
-      return;
-    }
-
-    Set<String> loadedKeys = new HashSet<>();
-
-    for (String line : fileLines) {
-      String trimmed = line.trim();
-      if (trimmed.isEmpty() || trimmed.startsWith("#")) {
-        continue;
-      }
-
-      String cleanLine = trimmed.replace("\\:", ":");
-      String[] parts = cleanLine.split("=", 2);
-      
-      if (parts.length == 2) {
-        String key = parts[0].trim();
-        String value = parts[1].trim();
-
-        String[] keyParts = parseKey(key);
-        String[] valueParts = parseValue(value);
-
-        if (keyParts != null && valueParts != null && !valueParts[0].isEmpty()) {
-          try {
-            String cleanKey = keyParts[0] + "::" + keyParts[1] + "::" + keyParts[2];
-            loadedKeys.add(cleanKey);
-            addBonusDropEntry(
-                keyParts[0],
-                Integer.parseInt(keyParts[1]),
-                keyParts[2],
-                Integer.parseInt(valueParts[2]),
-                valueParts[0],
-                Integer.parseInt(valueParts[1]));
-          } catch (NumberFormatException e) {
-            log.error("{} Invalid number format in config file {}: {}", LOG_PREFIX, CONFIG_FILE_NAME, line);
+    // Add default values to config file, handling the new List syntax
+    defaultMobFarmBonusMap.forEach(
+        (mobFarmName, bonusList) -> {
+          if (!properties.containsKey(mobFarmName)) {
+            if (bonusList.size() == 1) {
+              BonusDrop drop = bonusList.get(0);
+              String itemName = BuiltInRegistries.ITEM.getKey(drop.itemStack.getItem()).toString();
+              String value = itemName + "::" + drop.itemStack.getCount() + "::" + drop.chance;
+              properties.setProperty(mobFarmName, value);
+            } else {
+              StringBuilder sb = new StringBuilder("[");
+              for(int i = 0; i < bonusList.size(); i++) {
+                BonusDrop drop = bonusList.get(i);
+                String itemName = BuiltInRegistries.ITEM.getKey(drop.itemStack.getItem()).toString();
+                sb.append(itemName).append("::").append(drop.itemStack.getCount()).append("::").append(drop.chance);
+                if (i < bonusList.size() - 1) sb.append(", ");
+              }
+              sb.append("]");
+              properties.setProperty(mobFarmName, sb.toString());
+            }
           }
-        }
-      }
-    }
+        });
 
-    boolean needsUpdate = false;
-    List<String> appendLines = new ArrayList<>();
+    // Parse config file supporting both plain string and list [item1, item2] syntax
+    properties.forEach(
+        (key, value) -> {
+          String[] keyParts = parseKey((String) key);
+          if (keyParts == null) return;
 
-    for (Map.Entry<String, List<BonusDrop>> entry : defaultMobFarmBonusMap.entrySet()) {
-      String defaultKey = entry.getKey();
-      if (!loadedKeys.contains(defaultKey)) {
-        needsUpdate = true;
-        for (BonusDrop drop : entry.getValue()) {
-          String itemName = BuiltInRegistries.ITEM.getKey(drop.itemStack.getItem()).toString();
-          String writeKey = defaultKey.replace(":", "\\:");
-          String writeValue = (itemName + "::" + drop.itemStack.getCount() + "::" + drop.chance).replace(":", "\\:");
+          String valStr = ((String) value).trim();
           
-          appendLines.add(writeKey + "=" + writeValue);
+          if (valStr.startsWith("[") && valStr.endsWith("]")) {
+            valStr = valStr.substring(1, valStr.length() - 1);
+            String[] items = valStr.split(",");
+            for (String itemStr : items) {
+              parseAndAddDrop(keyParts, itemStr.trim());
+            }
+          } else {
+            parseAndAddDrop(keyParts, valStr);
+          }
+        });
 
-          addBonusDropEntry(
-              defaultKey.split("::")[0],
-              Integer.parseInt(defaultKey.split("::")[1]),
-              defaultKey.split("::")[2],
-              drop.chance,
-              itemName,
-              drop.itemStack.getCount());
-        }
-      }
-    }
+    // Update config file if needed
+    updateConfigFileIfChanged(configFile, CONFIG_FILE_HEADER, properties, unmodifiedProperties);
+  }
 
-    if (needsUpdate) {
-      try {
-        Files.write(configFile.toPath(), appendLines, StandardOpenOption.CREATE, StandardOpenOption.APPEND);
-      } catch (Exception e) {
-        log.error("{} Failed to update config file {}", LOG_PREFIX, CONFIG_FILE_NAME, e);
-      }
+  private static void parseAndAddDrop(String[] keyParts, String valueStr) {
+    String[] valueParts = parseValue(valueStr);
+    if (valueParts == null || valueParts[0].isEmpty()) return;
+
+    try {
+      addBonusDropEntry(
+          keyParts[0],
+          Integer.parseInt(keyParts[1]),
+          keyParts[2],
+          Integer.parseInt(valueParts[2]),
+          valueParts[0],
+          Integer.parseInt(valueParts[1]));
+    } catch (NumberFormatException e) {
+      log.error("{} Invalid number format in config file {}: key={}, value={}",
+          LOG_PREFIX, CONFIG_FILE_NAME, String.join("::", keyParts), valueStr);
     }
   }
 
@@ -365,6 +340,7 @@ public class MobFarmBonusConfig extends Config {
     mobFarmBonusMap.computeIfAbsent(mobFarmKey, k -> new ArrayList<>()).add(new BonusDrop(chance, itemStack));
   }
 
+  // Maintains UI stability by returning the first valid entry found for display
   public static ItemStack getBonusDropEntry(MobFarmType mobFarmType, int tierLevel, EntityType<?> entityType) {
     return getBonusDropEntry(mobFarmType.getId(), tierLevel, String.valueOf(BuiltInRegistries.ENTITY_TYPE.getKey(entityType)));
   }
@@ -374,9 +350,7 @@ public class MobFarmBonusConfig extends Config {
       return ItemStack.EMPTY;
     }
     String key = getMobFarmKey(mobFarmName, tierLevel, entityType);
-    List<BonusDrop> drops = mobFarmBonusMap.get(key);
-    int index = displayIndexMap.computeIfAbsent(key, k -> 0) % drops.size();
-    return drops.get(index).itemStack.copy();
+    return mobFarmBonusMap.get(key).get(0).itemStack.copy();
   }
 
   public static int getBonusDropChance(MobFarmType mobFarmType, int tierLevel, EntityType<?> entityType) {
@@ -388,35 +362,59 @@ public class MobFarmBonusConfig extends Config {
       return 0;
     }
     String key = getMobFarmKey(mobFarmName, tierLevel, entityType);
-    List<BonusDrop> drops = mobFarmBonusMap.get(key);
-    int index = displayIndexMap.computeIfAbsent(key, k -> 0) % drops.size();
-    return drops.get(index).chance;
+    return mobFarmBonusMap.get(key).get(0).chance;
   }
 
-  public static ItemStack getBonusDrop(MobFarmType mobFarmType, int tierLevel, EntityType<?> entityType) {
+  // --- CORE CHANGE: Now returns a List of independent drops ---
+  public static List<ItemStack> getBonusDrop(MobFarmType mobFarmType, int tierLevel, EntityType<?> entityType) {
     return getBonusDrop(mobFarmType.getId(), tierLevel, String.valueOf(BuiltInRegistries.ENTITY_TYPE.getKey(entityType)));
   }
 
-  public static ItemStack getBonusDrop(String mobFarmName, int tierLevel, String entityType) {
+  public static List<ItemStack> getBonusDrop(String mobFarmName, int tierLevel, String entityType) {
+    List<ItemStack> drops = new ArrayList<>();
     if (!hasBonusDrop(mobFarmName, tierLevel, entityType)) {
-      return ItemStack.EMPTY;
+      return drops;
     }
     
     String key = getMobFarmKey(mobFarmName, tierLevel, entityType);
-    List<BonusDrop> drops = mobFarmBonusMap.get(key);
     
-    int currentIndex = displayIndexMap.computeIfAbsent(key, k -> 0) % drops.size();
-    BonusDrop currentDrop = drops.get(currentIndex);
-    
-    displayIndexMap.put(key, (currentIndex + 1) % drops.size());
-    
-    double adjustedProbability = (double) drops.size() / currentDrop.chance;
-    
-    if (random.nextDouble() < adjustedProbability) {
-      return currentDrop.itemStack.copy();
+    // Each item rolls entirely independently
+    for (BonusDrop drop : mobFarmBonusMap.get(key)) {
+      if (random.nextInt(drop.chance) == 0) {
+        drops.add(drop.itemStack.copy());
+      }
     }
     
-    return ItemStack.EMPTY;
+    return drops;
+  }
+
+  public static List<ItemStack> getBonusDropEntries(MobFarmType mobFarmType, int tierLevel, EntityType<?> entityType) {
+    return getBonusDropEntries(mobFarmType.getId(), tierLevel, String.valueOf(BuiltInRegistries.ENTITY_TYPE.getKey(entityType)));
+  }
+
+
+  public static List<BonusDrop> getConfiguredBonusDrops(MobFarmType mobFarmType, int tierLevel, EntityType<?> entityType) {
+    return getConfiguredBonusDrops(mobFarmType.getId(), tierLevel, String.valueOf(BuiltInRegistries.ENTITY_TYPE.getKey(entityType)));
+  }
+
+  public static List<BonusDrop> getConfiguredBonusDrops(String mobFarmName, int tierLevel, String entityType) {
+    if (!hasBonusDrop(mobFarmName, tierLevel, entityType)) {
+      return new ArrayList<>();
+    }
+    String key = getMobFarmKey(mobFarmName, tierLevel, entityType);
+    return mobFarmBonusMap.get(key);
+  }
+
+  public static List<ItemStack> getBonusDropEntries(String mobFarmName, int tierLevel, String entityType) {
+    List<ItemStack> displayItems = new ArrayList<>();
+    if (!hasBonusDrop(mobFarmName, tierLevel, entityType)) {
+      return displayItems;
+    }
+    String key = getMobFarmKey(mobFarmName, tierLevel, entityType);
+    for (BonusDrop drop : mobFarmBonusMap.get(key)) {
+      displayItems.add(drop.itemStack.copy());
+    }
+    return displayItems;
   }
 
   public static boolean hasBonusDrop(String mobFarmName, int tierLevel, EntityType<?> entityType) {

--- a/Common/src/main/java/de/markusbordihn/easymobfarm/config/MobFarmBonusConfig.java
+++ b/Common/src/main/java/de/markusbordihn/easymobfarm/config/MobFarmBonusConfig.java
@@ -410,7 +410,9 @@ public class MobFarmBonusConfig extends Config {
     
     displayIndexMap.put(key, (currentIndex + 1) % drops.size());
     
-    if (random.nextInt(currentDrop.chance) == 0) {
+    double adjustedProbability = (double) drops.size() / currentDrop.chance;
+    
+    if (random.nextDouble() < adjustedProbability) {
       return currentDrop.itemStack.copy();
     }
     

--- a/Common/src/main/java/de/markusbordihn/easymobfarm/config/MobFarmBonusConfig.java
+++ b/Common/src/main/java/de/markusbordihn/easymobfarm/config/MobFarmBonusConfig.java
@@ -28,6 +28,7 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Random;
+import java.util.StringJoiner;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.entity.EntityType;
@@ -40,155 +41,291 @@ public class MobFarmBonusConfig extends Config {
   public static final String CONFIG_FILE_NAME = "mob_farm_bonus.cfg";
   public static final String CONFIG_FILE_HEADER =
 """
-# Mob Farm Bonus Configuration
-#
-# This configuration file allows you to define the bonus drops for the Mob Farms.
-#
-# Configuration Format:
-# --------------------
-# <mob_farm_name>::<tier_level>::<entity_type> = <item_name>::<amount>::<chance 1 of x>
-#
-# Available Mob Farm Types:
-# ------------------------
-# - animal_plains_farm: For animals like cows, sheep, chickens, pigs
-# - bee_hive_farm: For bees and honey production
-# - desert_farm: For desert mobs like husks, rabbits, camels
-# - iron_golem_farm: For iron golems and poppy drops
-# - jungle_farm: For jungle mobs like parrots, pandas, ocelots
-# - monster_plains_cave_farm: For common monsters like zombies, skeletons, spiders
-# - nether_fortress_farm: For nether mobs like blazes, magma cubes, wither skeletons
-# - ocean_farm: For ocean mobs like cod, salmon, squid, guardians
-# - swamp_farm: For swamp mobs like frogs, slimes, witches
-#
-# Tier Levels (better farms = better bonus chances):
-# -------------------------------------------------
-# - 0: Basic tier (lowest bonus chance)
-# - 1: Improved tier (better bonus chance)
-# - 2: Advanced tier (good bonus chance)
-# - 3: Elite tier (highest bonus chance)
-#
-# Configuration Examples:
-# ----------------------
-# Basic bee farm with 1 in 20 chance for honeycomb:
-#   bee_hive_farm::0::minecraft:bee = minecraft:honeycomb::1::20
-#
-# Elite bee farm with 1 in 5 chance for honeycomb:
-#   bee_hive_farm::3::minecraft:bee = minecraft:honeycomb::1::5
-#
-# Multiple bonus items for the same mob (using list syntax):
-#   ocean_farm::1::minecraft:cod = [minecraft:cod::1::10, minecraft:bone_meal::1::25]
-#
-# Important Notes:
-# ---------------
-# - Lower chance numbers = higher drop probability (1 = always, 100 = 1% chance)
-# - To disable a bonus drop, set the amount to 0
-# - Each mob farm type targets specific biome-appropriate mobs
-# - Higher tier farms have better default bonus chances
+ Mob Farm Bonus Configuration
+
+ This configuration file allows you to define the bonus drops for the Mob Farms.
+
+ Configuration Format:
+ --------------------
+ <mob_farm_name>::<tier_level>::<entity_type> = <item_name>::<amount>::<chance 1 of x>
+
+ Available Mob Farm Types:
+ ------------------------
+ - animal_plains_farm: For animals like cows, sheep, chickens, pigs
+ - bee_hive_farm: For bees and honey production
+ - desert_farm: For desert mobs like husks, rabbits, camels
+ - iron_golem_farm: For iron golems and poppy drops
+ - jungle_farm: For jungle mobs like parrots, pandas, ocelots
+ - monster_plains_cave_farm: For common monsters like zombies, skeletons, spiders
+ - nether_fortress_farm: For nether mobs like blazes, magma cubes, wither skeletons
+ - ocean_farm: For ocean mobs like cod, salmon, squid, guardians
+ - swamp_farm: For swamp mobs like frogs, slimes, witches
+
+ Tier Levels (better farms = better bonus chances):
+ -------------------------------------------------
+ - 0: Basic tier (lowest bonus chance)
+ - 1: Improved tier (better bonus chance)
+ - 2: Advanced tier (good bonus chance)
+ - 3: Elite tier (highest bonus chance)
+
+ Configuration Examples:
+ ----------------------
+ Basic bee farm with 1 in 20 chance for honeycomb:
+   bee_hive_farm::0::minecraft:bee = minecraft:honeycomb::1::20
+
+ Elite bee farm with 1 in 5 chance for honeycomb:
+   bee_hive_farm::3::minecraft:bee = minecraft:honeycomb::1::5
+
+ Iron golem farm with bonus iron ingots:
+   iron_golem_farm::2::minecraft:iron_golem = minecraft:iron_ingot::2::8
+
+ Multiple bonus items for the same mob (using list syntax):
+   ocean_farm::1::minecraft:cod = [minecraft:cod::1::10, minecraft:bone_meal::1::25]
+
+ Important Notes:
+ ---------------
+ - Lower chance numbers = higher drop probability (1 = always, 100 = 1% chance)
+ - To disable a bonus drop, set the amount to 0
+ - Each mob farm type targets specific biome-appropriate mobs
+ - Higher tier farms have better default bonus chances
 
 """;
   public static final String LOG_PREFIX = "[MobFarmBonusConfig]";
 
   private static final Random random = new Random();
-
-  public static class BonusDrop {
-    public final int chance;
-    public final ItemStack itemStack;
-
-    public BonusDrop(int chance, ItemStack itemStack) {
-      this.chance = chance;
-      this.itemStack = itemStack;
-    }
-  }
-
   private static final HashMap<String, List<BonusDrop>> mobFarmBonusMap = new HashMap<>();
   private static final HashMap<String, List<BonusDrop>> defaultMobFarmBonusMap = new HashMap<>();
 
   static {
     // Animal Plains Farm Bonus
-    defaultMobFarmBonusMap.put(MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::0::minecraft:cow", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.LEATHER, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::1::minecraft:cow", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.LEATHER, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::2::minecraft:cow", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.LEATHER, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::3::minecraft:cow", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.LEATHER, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::0::minecraft:sheep", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.WHITE_WOOL, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::1::minecraft:sheep", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.WHITE_WOOL, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::2::minecraft:sheep", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.WHITE_WOOL, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::3::minecraft:sheep", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.WHITE_WOOL, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::0::minecraft:chicken", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.EGG, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::1::minecraft:chicken", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.EGG, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::2::minecraft:chicken", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.EGG, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::3::minecraft:chicken", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.EGG, 1)))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::0::minecraft:cow",
+        List.of(new BonusDrop(20, new ItemStack(Items.LEATHER, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::1::minecraft:cow",
+        List.of(new BonusDrop(15, new ItemStack(Items.LEATHER, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::2::minecraft:cow",
+        List.of(new BonusDrop(10, new ItemStack(Items.LEATHER, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::3::minecraft:cow",
+        List.of(new BonusDrop(5, new ItemStack(Items.LEATHER, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::0::minecraft:sheep",
+        List.of(new BonusDrop(20, new ItemStack(Items.WHITE_WOOL, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::1::minecraft:sheep",
+        List.of(new BonusDrop(15, new ItemStack(Items.WHITE_WOOL, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::2::minecraft:sheep",
+        List.of(new BonusDrop(10, new ItemStack(Items.WHITE_WOOL, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::3::minecraft:sheep",
+        List.of(new BonusDrop(5, new ItemStack(Items.WHITE_WOOL, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::0::minecraft:chicken",
+        List.of(new BonusDrop(20, new ItemStack(Items.EGG, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::1::minecraft:chicken",
+        List.of(new BonusDrop(15, new ItemStack(Items.EGG, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::2::minecraft:chicken",
+        List.of(new BonusDrop(10, new ItemStack(Items.EGG, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.ANIMAL_PLAINS_FARM.getId() + "::3::minecraft:chicken",
+        List.of(new BonusDrop(5, new ItemStack(Items.EGG, 1))));
 
     // Bee Hive Farm Bonus
-    defaultMobFarmBonusMap.put(MobFarmType.BEE_HIVE_FARM.getId() + "::0::minecraft:bee", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.HONEYCOMB, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.BEE_HIVE_FARM.getId() + "::1::minecraft:bee", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.HONEYCOMB, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.BEE_HIVE_FARM.getId() + "::2::minecraft:bee", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.HONEYCOMB, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.BEE_HIVE_FARM.getId() + "::3::minecraft:bee", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.HONEYCOMB, 1)))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.BEE_HIVE_FARM.getId() + "::0::minecraft:bee",
+        List.of(new BonusDrop(20, new ItemStack(Items.HONEYCOMB, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.BEE_HIVE_FARM.getId() + "::1::minecraft:bee",
+        List.of(new BonusDrop(15, new ItemStack(Items.HONEYCOMB, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.BEE_HIVE_FARM.getId() + "::2::minecraft:bee",
+        List.of(new BonusDrop(10, new ItemStack(Items.HONEYCOMB, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.BEE_HIVE_FARM.getId() + "::3::minecraft:bee",
+        List.of(new BonusDrop(5, new ItemStack(Items.HONEYCOMB, 1))));
 
     // Desert Farm Bonus
-    defaultMobFarmBonusMap.put(MobFarmType.DESERT_FARM.getId() + "::0::minecraft:husk", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.SAND, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.DESERT_FARM.getId() + "::1::minecraft:husk", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.SAND, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.DESERT_FARM.getId() + "::2::minecraft:husk", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.SAND, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.DESERT_FARM.getId() + "::3::minecraft:husk", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.SAND, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.DESERT_FARM.getId() + "::0::minecraft:rabbit", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.RABBIT_HIDE, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.DESERT_FARM.getId() + "::1::minecraft:rabbit", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.RABBIT_HIDE, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.DESERT_FARM.getId() + "::2::minecraft:rabbit", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.RABBIT_HIDE, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.DESERT_FARM.getId() + "::3::minecraft:rabbit", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.RABBIT_HIDE, 1)))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.DESERT_FARM.getId() + "::0::minecraft:husk",
+        List.of(new BonusDrop(20, new ItemStack(Items.SAND, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.DESERT_FARM.getId() + "::1::minecraft:husk",
+        List.of(new BonusDrop(15, new ItemStack(Items.SAND, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.DESERT_FARM.getId() + "::2::minecraft:husk",
+        List.of(new BonusDrop(10, new ItemStack(Items.SAND, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.DESERT_FARM.getId() + "::3::minecraft:husk",
+        List.of(new BonusDrop(5, new ItemStack(Items.SAND, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.DESERT_FARM.getId() + "::0::minecraft:rabbit",
+        List.of(new BonusDrop(20, new ItemStack(Items.RABBIT_HIDE, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.DESERT_FARM.getId() + "::1::minecraft:rabbit",
+        List.of(new BonusDrop(15, new ItemStack(Items.RABBIT_HIDE, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.DESERT_FARM.getId() + "::2::minecraft:rabbit",
+        List.of(new BonusDrop(10, new ItemStack(Items.RABBIT_HIDE, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.DESERT_FARM.getId() + "::3::minecraft:rabbit",
+        List.of(new BonusDrop(5, new ItemStack(Items.RABBIT_HIDE, 1))));
 
     // Iron Golem Farm Bonus
-    defaultMobFarmBonusMap.put(MobFarmType.IRON_GOLEM_FARM.getId() + "::0::minecraft:iron_golem", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.IRON_INGOT, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.IRON_GOLEM_FARM.getId() + "::1::minecraft:iron_golem", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.IRON_INGOT, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.IRON_GOLEM_FARM.getId() + "::2::minecraft:iron_golem", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.IRON_INGOT, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.IRON_GOLEM_FARM.getId() + "::3::minecraft:iron_golem", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.IRON_INGOT, 1)))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.IRON_GOLEM_FARM.getId() + "::0::minecraft:iron_golem",
+        List.of(new BonusDrop(20, new ItemStack(Items.IRON_INGOT, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.IRON_GOLEM_FARM.getId() + "::1::minecraft:iron_golem",
+        List.of(new BonusDrop(15, new ItemStack(Items.IRON_INGOT, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.IRON_GOLEM_FARM.getId() + "::2::minecraft:iron_golem",
+        List.of(new BonusDrop(10, new ItemStack(Items.IRON_INGOT, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.IRON_GOLEM_FARM.getId() + "::3::minecraft:iron_golem",
+        List.of(new BonusDrop(5, new ItemStack(Items.IRON_INGOT, 1))));
 
     // Jungle Farm Bonus
-    defaultMobFarmBonusMap.put(MobFarmType.JUNGLE_FARM.getId() + "::0::minecraft:parrot", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.FEATHER, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.JUNGLE_FARM.getId() + "::1::minecraft:parrot", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.FEATHER, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.JUNGLE_FARM.getId() + "::2::minecraft:parrot", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.FEATHER, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.JUNGLE_FARM.getId() + "::3::minecraft:parrot", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.FEATHER, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.JUNGLE_FARM.getId() + "::0::minecraft:panda", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.BAMBOO, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.JUNGLE_FARM.getId() + "::1::minecraft:panda", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.BAMBOO, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.JUNGLE_FARM.getId() + "::2::minecraft:panda", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.BAMBOO, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.JUNGLE_FARM.getId() + "::3::minecraft:panda", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.BAMBOO, 1)))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.JUNGLE_FARM.getId() + "::0::minecraft:parrot",
+        List.of(new BonusDrop(20, new ItemStack(Items.FEATHER, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.JUNGLE_FARM.getId() + "::1::minecraft:parrot",
+        List.of(new BonusDrop(15, new ItemStack(Items.FEATHER, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.JUNGLE_FARM.getId() + "::2::minecraft:parrot",
+        List.of(new BonusDrop(10, new ItemStack(Items.FEATHER, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.JUNGLE_FARM.getId() + "::3::minecraft:parrot",
+        List.of(new BonusDrop(5, new ItemStack(Items.FEATHER, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.JUNGLE_FARM.getId() + "::0::minecraft:panda",
+        List.of(new BonusDrop(20, new ItemStack(Items.BAMBOO, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.JUNGLE_FARM.getId() + "::1::minecraft:panda",
+        List.of(new BonusDrop(15, new ItemStack(Items.BAMBOO, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.JUNGLE_FARM.getId() + "::2::minecraft:panda",
+        List.of(new BonusDrop(10, new ItemStack(Items.BAMBOO, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.JUNGLE_FARM.getId() + "::3::minecraft:panda",
+        List.of(new BonusDrop(5, new ItemStack(Items.BAMBOO, 1))));
 
     // Monster Plains Cave Farm Bonus
-    defaultMobFarmBonusMap.put(MobFarmType.MONSTER_PLAINS_CAVE_FARM.getId() + "::0::minecraft:zombie", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.ROTTEN_FLESH, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.MONSTER_PLAINS_CAVE_FARM.getId() + "::1::minecraft:zombie", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.ROTTEN_FLESH, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.MONSTER_PLAINS_CAVE_FARM.getId() + "::2::minecraft:zombie", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.ROTTEN_FLESH, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.MONSTER_PLAINS_CAVE_FARM.getId() + "::3::minecraft:zombie", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.ROTTEN_FLESH, 1)))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.MONSTER_PLAINS_CAVE_FARM.getId() + "::0::minecraft:zombie",
+        List.of(
+            new BonusDrop(20, new ItemStack(Items.ROTTEN_FLESH, 1)),
+            new BonusDrop(40, new ItemStack(Items.IRON_NUGGET, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.MONSTER_PLAINS_CAVE_FARM.getId() + "::1::minecraft:zombie",
+        List.of(
+            new BonusDrop(15, new ItemStack(Items.ROTTEN_FLESH, 1)),
+            new BonusDrop(25, new ItemStack(Items.IRON_NUGGET, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.MONSTER_PLAINS_CAVE_FARM.getId() + "::2::minecraft:zombie",
+        List.of(
+            new BonusDrop(10, new ItemStack(Items.ROTTEN_FLESH, 1)),
+            new BonusDrop(15, new ItemStack(Items.IRON_NUGGET, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.MONSTER_PLAINS_CAVE_FARM.getId() + "::3::minecraft:zombie",
+        List.of(
+            new BonusDrop(5, new ItemStack(Items.ROTTEN_FLESH, 1)),
+            new BonusDrop(10, new ItemStack(Items.IRON_NUGGET, 1))));
 
     // Nether Fortress Farm Bonus
-    defaultMobFarmBonusMap.put(MobFarmType.NETHER_FORTRESS_FARM.getId() + "::0::minecraft:blaze", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.BLAZE_ROD, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.NETHER_FORTRESS_FARM.getId() + "::1::minecraft:blaze", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.BLAZE_ROD, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.NETHER_FORTRESS_FARM.getId() + "::2::minecraft:blaze", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.BLAZE_ROD, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.NETHER_FORTRESS_FARM.getId() + "::3::minecraft:blaze", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.BLAZE_ROD, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.NETHER_FORTRESS_FARM.getId() + "::0::minecraft:magma_cube", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.MAGMA_CREAM, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.NETHER_FORTRESS_FARM.getId() + "::1::minecraft:magma_cube", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.MAGMA_CREAM, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.NETHER_FORTRESS_FARM.getId() + "::2::minecraft:magma_cube", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.MAGMA_CREAM, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.NETHER_FORTRESS_FARM.getId() + "::3::minecraft:magma_cube", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.MAGMA_CREAM, 1)))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.NETHER_FORTRESS_FARM.getId() + "::0::minecraft:blaze",
+        List.of(new BonusDrop(20, new ItemStack(Items.BLAZE_ROD, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.NETHER_FORTRESS_FARM.getId() + "::1::minecraft:blaze",
+        List.of(new BonusDrop(15, new ItemStack(Items.BLAZE_ROD, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.NETHER_FORTRESS_FARM.getId() + "::2::minecraft:blaze",
+        List.of(new BonusDrop(10, new ItemStack(Items.BLAZE_ROD, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.NETHER_FORTRESS_FARM.getId() + "::3::minecraft:blaze",
+        List.of(new BonusDrop(5, new ItemStack(Items.BLAZE_ROD, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.NETHER_FORTRESS_FARM.getId() + "::0::minecraft:magma_cube",
+        List.of(new BonusDrop(20, new ItemStack(Items.MAGMA_CREAM, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.NETHER_FORTRESS_FARM.getId() + "::1::minecraft:magma_cube",
+        List.of(new BonusDrop(15, new ItemStack(Items.MAGMA_CREAM, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.NETHER_FORTRESS_FARM.getId() + "::2::minecraft:magma_cube",
+        List.of(new BonusDrop(10, new ItemStack(Items.MAGMA_CREAM, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.NETHER_FORTRESS_FARM.getId() + "::3::minecraft:magma_cube",
+        List.of(new BonusDrop(5, new ItemStack(Items.MAGMA_CREAM, 1))));
 
     // Ocean Farm Bonus
-    defaultMobFarmBonusMap.put(MobFarmType.OCEAN_FARM.getId() + "::0::minecraft:cod", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.COD, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.OCEAN_FARM.getId() + "::1::minecraft:cod", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.COD, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.OCEAN_FARM.getId() + "::2::minecraft:cod", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.COD, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.OCEAN_FARM.getId() + "::3::minecraft:cod", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.COD, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.OCEAN_FARM.getId() + "::0::minecraft:squid", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.INK_SAC, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.OCEAN_FARM.getId() + "::1::minecraft:squid", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.INK_SAC, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.OCEAN_FARM.getId() + "::2::minecraft:squid", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.INK_SAC, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.OCEAN_FARM.getId() + "::3::minecraft:squid", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.INK_SAC, 1)))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.OCEAN_FARM.getId() + "::0::minecraft:cod",
+        List.of(new BonusDrop(20, new ItemStack(Items.COD, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.OCEAN_FARM.getId() + "::1::minecraft:cod",
+        List.of(new BonusDrop(15, new ItemStack(Items.COD, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.OCEAN_FARM.getId() + "::2::minecraft:cod",
+        List.of(new BonusDrop(10, new ItemStack(Items.COD, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.OCEAN_FARM.getId() + "::3::minecraft:cod",
+        List.of(new BonusDrop(5, new ItemStack(Items.COD, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.OCEAN_FARM.getId() + "::0::minecraft:squid",
+        List.of(new BonusDrop(20, new ItemStack(Items.INK_SAC, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.OCEAN_FARM.getId() + "::1::minecraft:squid",
+        List.of(new BonusDrop(15, new ItemStack(Items.INK_SAC, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.OCEAN_FARM.getId() + "::2::minecraft:squid",
+        List.of(new BonusDrop(10, new ItemStack(Items.INK_SAC, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.OCEAN_FARM.getId() + "::3::minecraft:squid",
+        List.of(new BonusDrop(5, new ItemStack(Items.INK_SAC, 1))));
 
     // Swamp Farm Bonus
-    defaultMobFarmBonusMap.put(MobFarmType.SWAMP_FARM.getId() + "::0::minecraft:frog", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.SLIME_BALL, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.SWAMP_FARM.getId() + "::1::minecraft:frog", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.SLIME_BALL, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.SWAMP_FARM.getId() + "::2::minecraft:frog", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.SLIME_BALL, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.SWAMP_FARM.getId() + "::3::minecraft:frog", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.SLIME_BALL, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.SWAMP_FARM.getId() + "::0::minecraft:slime", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.SLIME_BALL, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.SWAMP_FARM.getId() + "::1::minecraft:slime", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.SLIME_BALL, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.SWAMP_FARM.getId() + "::2::minecraft:slime", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.SLIME_BALL, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.SWAMP_FARM.getId() + "::3::minecraft:slime", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.SLIME_BALL, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.SWAMP_FARM.getId() + "::0::minecraft:witch", new ArrayList<>(List.of(new BonusDrop(20, new ItemStack(Items.REDSTONE, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.SWAMP_FARM.getId() + "::1::minecraft:witch", new ArrayList<>(List.of(new BonusDrop(15, new ItemStack(Items.REDSTONE, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.SWAMP_FARM.getId() + "::2::minecraft:witch", new ArrayList<>(List.of(new BonusDrop(10, new ItemStack(Items.REDSTONE, 1)))));
-    defaultMobFarmBonusMap.put(MobFarmType.SWAMP_FARM.getId() + "::3::minecraft:witch", new ArrayList<>(List.of(new BonusDrop(5, new ItemStack(Items.REDSTONE, 1)))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.SWAMP_FARM.getId() + "::0::minecraft:frog",
+        List.of(new BonusDrop(20, new ItemStack(Items.SLIME_BALL, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.SWAMP_FARM.getId() + "::1::minecraft:frog",
+        List.of(new BonusDrop(15, new ItemStack(Items.SLIME_BALL, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.SWAMP_FARM.getId() + "::2::minecraft:frog",
+        List.of(new BonusDrop(10, new ItemStack(Items.SLIME_BALL, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.SWAMP_FARM.getId() + "::3::minecraft:frog",
+        List.of(new BonusDrop(5, new ItemStack(Items.SLIME_BALL, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.SWAMP_FARM.getId() + "::0::minecraft:slime",
+        List.of(new BonusDrop(20, new ItemStack(Items.SLIME_BALL, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.SWAMP_FARM.getId() + "::1::minecraft:slime",
+        List.of(new BonusDrop(15, new ItemStack(Items.SLIME_BALL, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.SWAMP_FARM.getId() + "::2::minecraft:slime",
+        List.of(new BonusDrop(10, new ItemStack(Items.SLIME_BALL, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.SWAMP_FARM.getId() + "::3::minecraft:slime",
+        List.of(new BonusDrop(5, new ItemStack(Items.SLIME_BALL, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.SWAMP_FARM.getId() + "::0::minecraft:witch",
+        List.of(new BonusDrop(20, new ItemStack(Items.REDSTONE, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.SWAMP_FARM.getId() + "::1::minecraft:witch",
+        List.of(new BonusDrop(15, new ItemStack(Items.REDSTONE, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.SWAMP_FARM.getId() + "::2::minecraft:witch",
+        List.of(new BonusDrop(10, new ItemStack(Items.REDSTONE, 1))));
+    defaultMobFarmBonusMap.put(
+        MobFarmType.SWAMP_FARM.getId() + "::3::minecraft:witch",
+        List.of(new BonusDrop(5, new ItemStack(Items.REDSTONE, 1))));
   }
 
   public static void registerConfig() {
@@ -208,20 +345,19 @@ public class MobFarmBonusConfig extends Config {
         (mobFarmName, bonusList) -> {
           if (!properties.containsKey(mobFarmName)) {
             if (bonusList.size() == 1) {
-              BonusDrop drop = bonusList.get(0);
-              String itemName = BuiltInRegistries.ITEM.getKey(drop.itemStack.getItem()).toString();
-              String value = itemName + "::" + drop.itemStack.getCount() + "::" + drop.chance;
+              BonusDrop drop = bonusList.getFirst();
+              String itemName =
+                  BuiltInRegistries.ITEM.getKey(drop.itemStack().getItem()).toString();
+              String value = itemName + "::" + drop.itemStack().getCount() + "::" + drop.chance();
               properties.setProperty(mobFarmName, value);
             } else {
-              StringBuilder sb = new StringBuilder("[");
-              for(int i = 0; i < bonusList.size(); i++) {
-                BonusDrop drop = bonusList.get(i);
-                String itemName = BuiltInRegistries.ITEM.getKey(drop.itemStack.getItem()).toString();
-                sb.append(itemName).append("::").append(drop.itemStack.getCount()).append("::").append(drop.chance);
-                if (i < bonusList.size() - 1) sb.append(", ");
+              StringJoiner joiner = new StringJoiner(", ", "[", "]");
+              for (BonusDrop drop : bonusList) {
+                String itemName =
+                    BuiltInRegistries.ITEM.getKey(drop.itemStack().getItem()).toString();
+                joiner.add(itemName + "::" + drop.itemStack().getCount() + "::" + drop.chance());
               }
-              sb.append("]");
-              properties.setProperty(mobFarmName, sb.toString());
+              properties.setProperty(mobFarmName, joiner.toString());
             }
           }
         });
@@ -233,12 +369,11 @@ public class MobFarmBonusConfig extends Config {
           if (keyParts == null) return;
 
           String valStr = ((String) value).trim();
-          
+
           if (valStr.startsWith("[") && valStr.endsWith("]")) {
-            valStr = valStr.substring(1, valStr.length() - 1);
-            String[] items = valStr.split(",");
-            for (String itemStr : items) {
-              parseAndAddDrop(keyParts, itemStr.trim());
+            valStr = valStr.substring(1, valStr.length() - 1).trim();
+            for (String itemStr : valStr.split("\\s*,\\s*")) {
+              parseAndAddDrop(keyParts, itemStr);
             }
           } else {
             parseAndAddDrop(keyParts, valStr);
@@ -251,7 +386,15 @@ public class MobFarmBonusConfig extends Config {
 
   private static void parseAndAddDrop(String[] keyParts, String valueStr) {
     String[] valueParts = parseValue(valueStr);
-    if (valueParts == null || valueParts[0].isEmpty()) return;
+    if (valueParts == null) {
+      return;
+    }
+
+    String itemName = valueParts[0];
+    if (itemName.isEmpty()) {
+      log.error("{} Missing item name in config entry: {}", LOG_PREFIX, valueStr);
+      return;
+    }
 
     try {
       addBonusDropEntry(
@@ -259,11 +402,15 @@ public class MobFarmBonusConfig extends Config {
           Integer.parseInt(keyParts[1]),
           keyParts[2],
           Integer.parseInt(valueParts[2]),
-          valueParts[0],
+          itemName,
           Integer.parseInt(valueParts[1]));
     } catch (NumberFormatException e) {
-      log.error("{} Invalid number format in config file {}: key={}, value={}",
-          LOG_PREFIX, CONFIG_FILE_NAME, String.join("::", keyParts), valueStr);
+      log.error(
+          "{} Invalid number format in config file {}: key={}, value={}",
+          LOG_PREFIX,
+          CONFIG_FILE_NAME,
+          String.join("::", keyParts),
+          valueStr);
     }
   }
 
@@ -281,7 +428,8 @@ public class MobFarmBonusConfig extends Config {
 
     Optional<Item> item = BuiltInRegistries.ITEM.getOptional(Identifier.tryParse(itemName));
     if (item.isEmpty() || item.get() == Items.AIR) {
-      log.error("{} Invalid item name {} in config file {}", LOG_PREFIX, itemName, CONFIG_FILE_NAME);
+      log.error(
+          "{} Invalid item name {} in config file {}", LOG_PREFIX, itemName, CONFIG_FILE_NAME);
       return;
     }
 
@@ -290,7 +438,11 @@ public class MobFarmBonusConfig extends Config {
       addBonusDropEntry(
           mobFarmType, tierLevel, entityType, chance, new ItemStack(item.get(), amount));
     } catch (IllegalArgumentException e) {
-      log.error("{} Invalid mob farm name {} in config file {}", LOG_PREFIX, mobFarmName, CONFIG_FILE_NAME);
+      log.error(
+          "{} Invalid mob farm name {} in config file {}",
+          LOG_PREFIX,
+          mobFarmName,
+          CONFIG_FILE_NAME);
     }
   }
 
@@ -301,124 +453,132 @@ public class MobFarmBonusConfig extends Config {
       int chance,
       final ItemStack itemStack) {
 
+    // Check if item stack amount is valid
     if (itemStack.isEmpty()) {
-      log.error("{} Invalid item stack {} in config file {}", LOG_PREFIX, itemStack, CONFIG_FILE_NAME);
+      log.error(
+          "{} Invalid item stack {} in config file {}", LOG_PREFIX, itemStack, CONFIG_FILE_NAME);
       return;
     }
 
+    // Check if entity type is valid
     if (BuiltInRegistries.ENTITY_TYPE.getOptional(Identifier.tryParse(entityType)).isEmpty()) {
-      log.error("{} Invalid entity type {} in config file {}", LOG_PREFIX, entityType, CONFIG_FILE_NAME);
+      log.error(
+          "{} Invalid entity type {} in config file {}", LOG_PREFIX, entityType, CONFIG_FILE_NAME);
       return;
     }
 
+    // Validate tier level (0-3)
     if (tierLevel < 0 || tierLevel > 3) {
-      log.warn("{} Tier level {} is outside valid range (0-3) for {} in config file {}", LOG_PREFIX, tierLevel, entityType, CONFIG_FILE_NAME);
+      log.warn(
+          "{} Tier level {} is outside valid range (0-3) for {} in config file {}",
+          LOG_PREFIX,
+          tierLevel,
+          entityType,
+          CONFIG_FILE_NAME);
       tierLevel = 0;
     }
 
+    // Validate chance value (must be >= 1)
     if (chance < 1) {
-      log.warn("{} Invalid chance value {} (must be >= 1) for {} in config file {}, using default of 5", LOG_PREFIX, chance, entityType, CONFIG_FILE_NAME);
+      log.warn(
+          "{} Invalid chance value {} (must be >= 1) for {} in config file {}, using default of 5",
+          LOG_PREFIX,
+          chance,
+          entityType,
+          CONFIG_FILE_NAME);
       chance = 5;
     }
 
+    // Validate drop amount against item max stack size
     int maxStackSize = itemStack.getMaxStackSize();
     int configuredAmount = itemStack.getCount();
     int maxAllowedAmount = maxStackSize * MobFarmConfig.maxBonusDropMultiplier;
 
     if (configuredAmount > maxAllowedAmount) {
-      log.warn("{} Configured amount {} exceeds maximum allowed {} ({}x stack size of {}) for {} in config file {}, capping to maximum",
-          LOG_PREFIX, configuredAmount, maxAllowedAmount, MobFarmConfig.maxBonusDropMultiplier, maxStackSize, entityType, CONFIG_FILE_NAME);
+      log.warn(
+          "{} Configured amount {} exceeds maximum allowed {} ({}x stack size of {}) for {} in config file {}, capping to maximum",
+          LOG_PREFIX,
+          configuredAmount,
+          maxAllowedAmount,
+          MobFarmConfig.maxBonusDropMultiplier,
+          maxStackSize,
+          entityType,
+          CONFIG_FILE_NAME);
       itemStack.setCount(maxAllowedAmount);
     } else if (configuredAmount > maxStackSize * 10) {
-      log.warn("{} High drop amount {} configured ({}x stack size of {}) for {} - ensure your modpack supports this with storage mods",
-          LOG_PREFIX, configuredAmount, configuredAmount / maxStackSize, maxStackSize, entityType);
+      log.warn(
+          "{} High drop amount {} configured ({}x stack size of {}) for {} - ensure your modpack supports this with storage mods",
+          LOG_PREFIX,
+          configuredAmount,
+          configuredAmount / maxStackSize,
+          maxStackSize,
+          entityType);
     }
 
+    // Add bonus drop entry to the map
     String mobFarmKey = getMobFarmKey(mobFarmType.getId(), tierLevel, entityType);
-    log.info("{} Add {} with a chance of 1 of {} for {}.", LOG_PREFIX, mobFarmKey, chance, itemStack);
-    
-    mobFarmBonusMap.computeIfAbsent(mobFarmKey, k -> new ArrayList<>()).add(new BonusDrop(chance, itemStack));
+    log.info(
+        "{} Add {} with a chance of 1 of {} for {}.", LOG_PREFIX, mobFarmKey, chance, itemStack);
+
+    mobFarmBonusMap
+        .computeIfAbsent(mobFarmKey, k -> new ArrayList<>())
+        .add(new BonusDrop(chance, itemStack));
   }
 
-  // Maintains UI stability by returning the first valid entry found for display
-  public static ItemStack getBonusDropEntry(MobFarmType mobFarmType, int tierLevel, EntityType<?> entityType) {
-    return getBonusDropEntry(mobFarmType.getId(), tierLevel, String.valueOf(BuiltInRegistries.ENTITY_TYPE.getKey(entityType)));
-  }
-
-  public static ItemStack getBonusDropEntry(String mobFarmName, int tierLevel, String entityType) {
-    if (!hasBonusDrop(mobFarmName, tierLevel, entityType)) {
-      return ItemStack.EMPTY;
-    }
-    String key = getMobFarmKey(mobFarmName, tierLevel, entityType);
-    return mobFarmBonusMap.get(key).get(0).itemStack.copy();
-  }
-
-  public static int getBonusDropChance(MobFarmType mobFarmType, int tierLevel, EntityType<?> entityType) {
-    return getBonusDropChance(mobFarmType.getId(), tierLevel, String.valueOf(BuiltInRegistries.ENTITY_TYPE.getKey(entityType)));
-  }
-
-  public static int getBonusDropChance(String mobFarmName, int tierLevel, String entityType) {
-    if (!hasBonusDrop(mobFarmName, tierLevel, entityType)) {
-      return 0;
-    }
-    String key = getMobFarmKey(mobFarmName, tierLevel, entityType);
-    return mobFarmBonusMap.get(key).get(0).chance;
-  }
-
-  // --- CORE CHANGE: Now returns a List of independent drops ---
-  public static List<ItemStack> getBonusDrop(MobFarmType mobFarmType, int tierLevel, EntityType<?> entityType) {
-    return getBonusDrop(mobFarmType.getId(), tierLevel, String.valueOf(BuiltInRegistries.ENTITY_TYPE.getKey(entityType)));
+  public static List<ItemStack> getBonusDrop(
+      MobFarmType mobFarmType, int tierLevel, EntityType<?> entityType) {
+    return getBonusDrop(
+        mobFarmType.getId(),
+        tierLevel,
+        String.valueOf(BuiltInRegistries.ENTITY_TYPE.getKey(entityType)));
   }
 
   public static List<ItemStack> getBonusDrop(String mobFarmName, int tierLevel, String entityType) {
     List<ItemStack> drops = new ArrayList<>();
     if (!hasBonusDrop(mobFarmName, tierLevel, entityType)) {
-      return drops;
+      return List.of();
     }
-    
-    String key = getMobFarmKey(mobFarmName, tierLevel, entityType);
-    
-    // Each item rolls entirely independently
-    for (BonusDrop drop : mobFarmBonusMap.get(key)) {
-      if (random.nextInt(drop.chance) == 0) {
-        drops.add(drop.itemStack.copy());
+    for (BonusDrop drop : mobFarmBonusMap.get(getMobFarmKey(mobFarmName, tierLevel, entityType))) {
+      if (random.nextInt(drop.chance()) == 0) {
+        drops.add(drop.itemStack().copy());
       }
     }
-    
+
     return drops;
   }
 
-  public static List<ItemStack> getBonusDropEntries(MobFarmType mobFarmType, int tierLevel, EntityType<?> entityType) {
-    return getBonusDropEntries(mobFarmType.getId(), tierLevel, String.valueOf(BuiltInRegistries.ENTITY_TYPE.getKey(entityType)));
+  public static List<ItemStack> getBonusDropEntries(
+      MobFarmType mobFarmType, int tierLevel, EntityType<?> entityType) {
+    return getBonusDropEntries(
+        mobFarmType.getId(),
+        tierLevel,
+        String.valueOf(BuiltInRegistries.ENTITY_TYPE.getKey(entityType)));
   }
 
-
-  public static List<BonusDrop> getConfiguredBonusDrops(MobFarmType mobFarmType, int tierLevel, EntityType<?> entityType) {
-    return getConfiguredBonusDrops(mobFarmType.getId(), tierLevel, String.valueOf(BuiltInRegistries.ENTITY_TYPE.getKey(entityType)));
+  public static List<BonusDrop> getConfiguredBonusDrops(
+      MobFarmType mobFarmType, int tierLevel, EntityType<?> entityType) {
+    return getConfiguredBonusDrops(
+        mobFarmType.getId(),
+        tierLevel,
+        String.valueOf(BuiltInRegistries.ENTITY_TYPE.getKey(entityType)));
   }
 
-  public static List<BonusDrop> getConfiguredBonusDrops(String mobFarmName, int tierLevel, String entityType) {
+  public static List<BonusDrop> getConfiguredBonusDrops(
+      String mobFarmName, int tierLevel, String entityType) {
     if (!hasBonusDrop(mobFarmName, tierLevel, entityType)) {
-      return new ArrayList<>();
+      return List.of();
     }
-    String key = getMobFarmKey(mobFarmName, tierLevel, entityType);
-    return mobFarmBonusMap.get(key);
+    return List.copyOf(mobFarmBonusMap.get(getMobFarmKey(mobFarmName, tierLevel, entityType)));
   }
 
-  public static List<ItemStack> getBonusDropEntries(String mobFarmName, int tierLevel, String entityType) {
-    List<ItemStack> displayItems = new ArrayList<>();
+  public static List<ItemStack> getBonusDropEntries(
+      String mobFarmName, int tierLevel, String entityType) {
     if (!hasBonusDrop(mobFarmName, tierLevel, entityType)) {
-      return displayItems;
+      return List.of();
     }
-    String key = getMobFarmKey(mobFarmName, tierLevel, entityType);
-    for (BonusDrop drop : mobFarmBonusMap.get(key)) {
-      displayItems.add(drop.itemStack.copy());
-    }
-    return displayItems;
-  }
-
-  public static boolean hasBonusDrop(String mobFarmName, int tierLevel, EntityType<?> entityType) {
-    return hasBonusDrop(mobFarmName, tierLevel, String.valueOf(BuiltInRegistries.ENTITY_TYPE.getKey(entityType)));
+    return mobFarmBonusMap.get(getMobFarmKey(mobFarmName, tierLevel, entityType)).stream()
+        .map(drop -> drop.itemStack().copy())
+        .toList();
   }
 
   public static boolean hasBonusDrop(String mobFarmName, int tierLevel, String entityType) {
@@ -426,7 +586,7 @@ public class MobFarmBonusConfig extends Config {
   }
 
   private static String[] parseKey(String key) {
-    String[] keyParts = key.split("::");
+    String[] keyParts = key.split("\\s*::\\s*");
     if (keyParts.length != 3) {
       log.error("Invalid key format in config file: {}", key);
       return null;
@@ -435,11 +595,13 @@ public class MobFarmBonusConfig extends Config {
   }
 
   private static String[] parseValue(String value) {
-    String[] valueParts = value.split("::");
+    String[] valueParts = value.split("\\s*::\\s*");
     if (valueParts.length != 3) {
       log.error("Invalid value format in config file: {}", value);
       return null;
     }
     return valueParts;
   }
+
+  public record BonusDrop(int chance, ItemStack itemStack) {}
 }


### PR DESCRIPTION
Hi Markus Bordihn,

This PR fixes an issue with the bonus drop configuration. 

**The Issue:**
According to the `mob_farm_bonus.cfg` documentation, configuring multiple bonus items for the same mob across different lines should be supported. However, because the underlying data structure used a `Map`, duplicate keys were being overwritten during parsing. As a result, only the last configured item in the file would actually take effect.

**The Solution:**
1. **Data Structure Update:** Refactored the storage container to use a `List`, allowing all configured items for the same mob to be parsed and stored correctly without overwriting.
2. **Round-Robin Scheduling:** Implemented a sequential (round-robin) rotation for bonus drops. After each successful production cycle, the farm now correctly cycles to the next configured item in the list.
3. **Expected Value Correction:** Since a round-robin approach naturally dilutes the occurrence rate of individual items (waiting *N* turns for a specific item), I adjusted the probability logic. The drop chance for the currently active item is now multiplied by the total number of items configured for that key. This guarantees that the mathematical expectation (actual drop rate over time) perfectly matches the probabilities defined by the user in the config file.

I have thoroughly tested these changes locally, and everything works exactly as expected. Please let me know if you have any questions. Thank you!